### PR TITLE
Add support for pruning reaped DICOMs

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -139,10 +139,10 @@ argument-rgx=[a-z_][a-z0-9_]{1,30}$
 argument-name-hint=[a-z_][a-z0-9_]{1,30}$
 
 # Regular expression matching correct class attribute names
-class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{1,30}|(__.*__))$
 
 # Naming hint for class attribute names
-class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{1,30}|(__.*__))$
 
 # Regular expression matching correct inline iteration names
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ cache:
 install:
     - pip install .
     - pip install -U -r requirements-dev.txt
-    - ./test/install_deps.sh
 # Orthanc requirements
     - sudo apt-get update
     - sudo apt-get install build-essential unzip cmake mercurial
@@ -30,6 +29,8 @@ install:
       libgtest-dev libpng-dev libsqlite3-dev libssl-dev libjpeg-dev
       zlib1g-dev libdcmtk2-dev libboost1.48-all-dev libwrap0-dev
       libcharls-dev
+# Non-package Dep Install
+      - ./test/install_deps.sh
 
 script:
     - ./test/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,17 +18,31 @@ cache:
         - $TESTDATA_DIR
         - $ORTHANC_VERSION
 
+before_install:
+    - ln -s bin $VIRTUAL_ENV/sbin
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq
+          build-essential
+          cmake
+          libboost1.48-all-dev
+          libcharls-dev
+          libcurl4-openssl-dev
+          libdcmtk2-dev
+          libgtest-dev
+          libjpeg-dev
+          liblua5.1-0-dev
+          libpng-dev
+          libsqlite3-dev
+          libssl-dev
+          libwrap0-dev
+          mercurial
+          unzip
+          uuid-dev
+          zlib1g-dev
+
 install:
     - pip install .
     - pip install -U -r requirements-dev.txt
-# Orthanc requirements
-    - sudo apt-get update
-    - sudo apt-get install build-essential unzip cmake mercurial
-      uuid-dev libcurl4-openssl-dev liblua5.1-0-dev
-      libgtest-dev libpng-dev libsqlite3-dev libssl-dev libjpeg-dev
-      zlib1g-dev libdcmtk2-dev libboost1.48-all-dev libwrap0-dev
-      libcharls-dev
-# Non-package Dep Install
     - ./test/install_deps.sh
 
 script:
@@ -36,5 +50,5 @@ script:
     - ./test/lint.sh
 
 after_success:
-# Split out build steps to script to avoid yml parsing issues of the commands.
-- ./docker/build-trigger.sh Tag "${TRAVIS_TAG}" "${BUILD_TRIGGER_URL}"
+    # Split out build steps to script to avoid yml parsing issues of the commands.
+    - ./docker/build-trigger.sh Tag "${TRAVIS_TAG}" "${BUILD_TRIGGER_URL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 language: python
 python:
     - "2.7"
@@ -8,6 +8,8 @@ env:
         - DCMTK_VERSION="dcmtk-3.6.1_20150924"
         - DCMTK_DB_DIR="dcmtk_dicom_db"
         - TESTDATA_DIR="testdata"
+        - ORTHANC_VERSION="Orthanc-1.1.0"
+        - ORTHANC_BUILD="${ORTHANC_VERSION}Build"
 
 cache:
     pip: true
@@ -15,11 +17,19 @@ cache:
         - $DCMTK_VERSION
         - $DCMTK_DB_DIR
         - $TESTDATA_DIR
+        - $ORTHANC_BUILD
 
 install:
     - pip install .
     - pip install -U -r requirements-dev.txt
     - ./test/install_deps.sh
+# Orthanc requirements
+    - sudo apt-get update
+    - sudo apt-get install build-essential unzip cmake mercurial
+      uuid-dev libcurl4-openssl-dev liblua5.1-0-dev
+      libgtest-dev libpng-dev libsqlite3-dev libssl-dev libjpeg-dev
+      zlib1g-dev libdcmtk2-dev libboost1.48-all-dev libwrap0-dev
+      libcharls-dev
 
 script:
     - ./test/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,7 @@ install:
 
 script:
     - ./test/test.sh
-    - pylint --reports=no reaper
-    - pep8 --max-line-length=150 --ignore=E402 reaper
+    - ./test/lint.sh
 
 after_success:
 # Split out build steps to script to avoid yml parsing issues of the commands.

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
         - DCMTK_DB_DIR="dcmtk_dicom_db"
         - TESTDATA_DIR="testdata"
         - ORTHANC_VERSION="Orthanc-1.1.0"
-        - ORTHANC_BUILD="${ORTHANC_VERSION}Build"
 
 cache:
     pip: true
@@ -17,7 +16,7 @@ cache:
         - $DCMTK_VERSION
         - $DCMTK_DB_DIR
         - $TESTDATA_DIR
-        - $ORTHANC_BUILD
+        - $ORTHANC_VERSION
 
 install:
     - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
       zlib1g-dev libdcmtk2-dev libboost1.48-all-dev libwrap0-dev
       libcharls-dev
 # Non-package Dep Install
-      - ./test/install_deps.sh
+    - ./test/install_deps.sh
 
 script:
     - ./test/test.sh

--- a/bin/orthanc_reaper
+++ b/bin/orthanc_reaper
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+# vim: filetype=python
+
+import reaper.orthanc_reaper
+
+reaper.orthanc_reaper.main()

--- a/reaper/dicom_reaper.py
+++ b/reaper/dicom_reaper.py
@@ -11,13 +11,13 @@ from . import reaper
 log = logging.getLogger('reaper.dicom')
 
 
-class DicomNetReaper(reaper.Reaper):
+class DicomReaper(reaper.Reaper):
 
-    """DicomNetReaper class"""
+    """DicomReaper class"""
 
     def __init__(self, options):
         self.scu = scu.SCU(options.get('host'), options.get('port'), options.get('return_port'), options.get('aet'), options.get('aec'))
-        super(DicomNetReaper, self).__init__(self.scu.aec, options)
+        super(DicomReaper, self).__init__(self.scu.aec, options)
         self.anonymize = options.get('anonymize')
 
         self.query_tags = {self.map_key: ''}
@@ -92,6 +92,6 @@ def update_arg_parser(ap):
     return ap
 
 
-def main():
+def main(cls=DicomReaper, arg_parser_update=update_arg_parser):
     # pylint: disable=missing-docstring
-    reaper.main(DicomNetReaper, update_arg_parser)
+    reaper.main(cls, arg_parser_update)

--- a/reaper/orthanc_reaper.py
+++ b/reaper/orthanc_reaper.py
@@ -1,21 +1,20 @@
-""" SciTran Orthanc Net Reaper """
+""" SciTran Orthanc DICOM Reaper """
 
 import logging
 import requests
 
-from . import reaper
 from . import dicom_reaper
 
-log = logging.getLogger('reaper.dicom')
+log = logging.getLogger('reaper.orthanc')
 
 
-class OrthancNetReaper(dicom_reaper.DicomNetReaper):
+class OrthancReaper(dicom_reaper.DicomReaper):
 
-    """OrthancNetReaper class"""
+    """OrthancReaper class"""
 
     def __init__(self, options):
-        super(OrthancNetReaper, self).__init__(options)
-        self.remote_host = options.get('host')
+        super(OrthancReaper, self).__init__(options)
+        self.orthanc_host = options.get('orthanc_host')
 
     def before_reap(self, _id):
         """
@@ -25,7 +24,7 @@ class OrthancNetReaper(dicom_reaper.DicomNetReaper):
                                error("All Stores Rejected")
                                end """
         with requests.Session() as rs:
-            exec_script_resp = rs.post('http://{0}:8104/tools/execute-script'.format(self.remote_host), data=disable_function)
+            exec_script_resp = rs.post('http://{0}/tools/execute-script'.format(self.orthanc_host), data=disable_function)
             exec_script_resp.raise_for_status()
 
     def after_reap_success(self, _id):
@@ -34,7 +33,7 @@ class OrthancNetReaper(dicom_reaper.DicomNetReaper):
         """
         with requests.Session() as rs:
             log.info(_id)
-            lookup_resp = rs.post('http://{0}:8104/tools/lookup'.format(self.remote_host), data=_id)
+            lookup_resp = rs.post('http://{0}/tools/lookup'.format(self.orthanc_host), data=_id)
             lookup_resp.raise_for_status()
             response_obj = lookup_resp.json()
             log.info(response_obj)
@@ -42,7 +41,7 @@ class OrthancNetReaper(dicom_reaper.DicomNetReaper):
                 raise Exception("Unexpected state: More than 1 series with same UID")
             log.info(response_obj[0]['ID'])
 
-            delete_resp = rs.delete('http://{0}:8104/series/{1}'.format(self.remote_host, response_obj[0]['ID']))
+            delete_resp = rs.delete('http://{0}/series/{1}'.format(self.orthanc_host, response_obj[0]['ID']))
             delete_resp.raise_for_status()
 
     def after_reap(self, _id):
@@ -53,10 +52,17 @@ class OrthancNetReaper(dicom_reaper.DicomNetReaper):
                                return true
                                end """
         with requests.Session() as rs:
-            exec_script_resp = rs.post('http://{0}:8104/tools/execute-script'.format(self.remote_host), data=enable_function)
+            exec_script_resp = rs.post('http://{0}/tools/execute-script'.format(self.orthanc_host), data=enable_function)
             exec_script_resp.raise_for_status()
 
 
-def main():
+def update_arg_parser(ap):
     # pylint: disable=missing-docstring
-    reaper.main(OrthancNetReaper, dicom_reaper.update_arg_parser)
+    ap = dicom_reaper.update_arg_parser(ap)
+    ap.add_argument('orthanc_host', help='Orthanc hostname and port')
+    return ap
+
+
+def main(cls=OrthancReaper, arg_parser_update=update_arg_parser):
+    # pylint: disable=missing-docstring
+    dicom_reaper.main(cls, arg_parser_update)

--- a/reaper/orthanc_reaper.py
+++ b/reaper/orthanc_reaper.py
@@ -1,13 +1,8 @@
 """ SciTran Orthanc Net Reaper """
 
-import os
 import logging
-import datetime
 import requests
 
-
-from . import dcm
-from . import scu
 from . import reaper
 from . import dicom_reaper
 
@@ -48,7 +43,7 @@ class OrthancNetReaper(dicom_reaper.DicomNetReaper):
             log.info(response_obj[0]['ID'])
 
             delete_resp = rs.delete('http://{0}:8104/series/{1}'.format(self.remote_host, response_obj[0]['ID']))
-            lookup_resp.raise_for_status()
+            delete_resp.raise_for_status()
 
     def after_reap(self, _id):
         """

--- a/reaper/orthanc_reaper.py
+++ b/reaper/orthanc_reaper.py
@@ -22,8 +22,6 @@ class OrthancNetReaper(dicom_reaper.DicomNetReaper):
         super(OrthancNetReaper, self).__init__(options)
         self.remote_host = options.get('host')
 
-
-
     def before_reap(self, _id):
         """
         Orthanc halt incoming stores
@@ -34,7 +32,6 @@ class OrthancNetReaper(dicom_reaper.DicomNetReaper):
         with requests.Session() as rs:
             exec_script_resp = rs.post('http://{0}:8104/tools/execute-script'.format(self.remote_host), data=disable_function)
             exec_script_resp.raise_for_status()
-
 
     def after_reap_success(self, _id):
         """
@@ -53,11 +50,6 @@ class OrthancNetReaper(dicom_reaper.DicomNetReaper):
             delete_resp = rs.delete('http://{0}:8104/series/{1}'.format(self.remote_host, response_obj[0]['ID']))
             lookup_resp.raise_for_status()
 
-
-
-
-
-
     def after_reap(self, _id):
         """
         Orthanc allow incoming stores
@@ -68,7 +60,6 @@ class OrthancNetReaper(dicom_reaper.DicomNetReaper):
         with requests.Session() as rs:
             exec_script_resp = rs.post('http://{0}:8104/tools/execute-script'.format(self.remote_host), data=enable_function)
             exec_script_resp.raise_for_status()
-
 
 
 def main():

--- a/reaper/orthanc_reaper.py
+++ b/reaper/orthanc_reaper.py
@@ -1,0 +1,76 @@
+""" SciTran Orthanc Net Reaper """
+
+import os
+import logging
+import datetime
+import requests
+
+
+from . import dcm
+from . import scu
+from . import reaper
+from . import dicom_reaper
+
+log = logging.getLogger('reaper.dicom')
+
+
+class OrthancNetReaper(dicom_reaper.DicomNetReaper):
+
+    """OrthancNetReaper class"""
+
+    def __init__(self, options):
+        super(OrthancNetReaper, self).__init__(options)
+        self.remote_host = options.get('host')
+
+
+
+    def before_reap(self, _id):
+        """
+        Orthanc halt incoming stores
+        """
+        disable_function = """ function ReceivedInstanceFilter(dicom, origin)
+                               error("All Stores Rejected")
+                               end """
+        with requests.Session() as rs:
+            exec_script_resp = rs.post('http://{0}:8104/tools/execute-script'.format(self.remote_host), data=disable_function)
+            exec_script_resp.raise_for_status()
+
+
+    def after_reap_success(self, _id):
+        """
+        Orthanc delete study
+        """
+        with requests.Session() as rs:
+            log.info(_id)
+            lookup_resp = rs.post('http://{0}:8104/tools/lookup'.format(self.remote_host), data=_id)
+            lookup_resp.raise_for_status()
+            response_obj = lookup_resp.json()
+            log.info(response_obj)
+            if len(response_obj) != 1:
+                raise Exception("Unexpected state: More than 1 series with same UID")
+            log.info(response_obj[0]['ID'])
+
+            delete_resp = rs.delete('http://{0}:8104/series/{1}'.format(self.remote_host, response_obj[0]['ID']))
+            lookup_resp.raise_for_status()
+
+
+
+
+
+
+    def after_reap(self, _id):
+        """
+        Orthanc allow incoming stores
+        """
+        enable_function = """ function ReceivedInstanceFilter(dicom, origin)
+                               return true
+                               end """
+        with requests.Session() as rs:
+            exec_script_resp = rs.post('http://{0}:8104/tools/execute-script'.format(self.remote_host), data=enable_function)
+            exec_script_resp.raise_for_status()
+
+
+
+def main():
+    # pylint: disable=missing-docstring
+    reaper.main(OrthancNetReaper, dicom_reaper.update_arg_parser)

--- a/reaper/orthanc_reaper.py
+++ b/reaper/orthanc_reaper.py
@@ -12,8 +12,6 @@ class OrthancReaper(dicom_reaper.DicomReaper):
 
     """OrthancReaper class"""
 
-    rs = requests.Session()
-
     def __init__(self, options):
         super(OrthancReaper, self).__init__(options)
         self.orthanc_uri = options.get('orthanc_uri').strip('/')
@@ -25,7 +23,7 @@ class OrthancReaper(dicom_reaper.DicomReaper):
         disable_function = """ function ReceivedInstanceFilter(dicom, origin)
                                error("All Stores Rejected")
                                end """
-        r = self.rs.post(self.orthanc_uri + '/tools/execute-script', data=disable_function)
+        r = requests.post(self.orthanc_uri + '/tools/execute-script', data=disable_function)
         r.raise_for_status()
 
     def after_reap_success(self, _id):
@@ -33,7 +31,7 @@ class OrthancReaper(dicom_reaper.DicomReaper):
         Orthanc delete study
         """
         log.info(_id)
-        r = self.rs.post(self.orthanc_uri + '/tools/lookup', data=_id)
+        r = requests.post(self.orthanc_uri + '/tools/lookup', data=_id)
         r.raise_for_status()
         payload = r.json()
         log.info(payload)
@@ -41,7 +39,7 @@ class OrthancReaper(dicom_reaper.DicomReaper):
             raise Exception("Unexpected state: More than 1 series with same UID")
         log.info(payload[0]['ID'])
 
-        r = self.rs.delete(self.orthanc_uri + '/series/' + payload[0]['ID'])
+        r = requests.delete(self.orthanc_uri + '/series/' + payload[0]['ID'])
         r.raise_for_status()
 
     def after_reap(self, _id):
@@ -51,7 +49,7 @@ class OrthancReaper(dicom_reaper.DicomReaper):
         enable_function = """ function ReceivedInstanceFilter(dicom, origin)
                                return true
                                end """
-        r = self.rs.post(self.orthanc_uri + '/tools/execute-script', data=enable_function)
+        r = requests.post(self.orthanc_uri + '/tools/execute-script', data=enable_function)
         r.raise_for_status()
 
 

--- a/reaper/reaper.py
+++ b/reaper/reaper.py
@@ -89,6 +89,19 @@ class Reaper(object):
         # pylint: disable=missing-docstring
         pass
 
+    def before_reap(self, _id):
+        # pylint: disable=missing-docstring
+        pass
+
+    def after_reap_success(self, _id):
+        # pylint: disable=missing-docstring
+        pass
+
+    def after_reap(self, _id):
+        # pylint: disable=missing-docstring
+        pass
+
+
     def __get_instrument_state(self):
         query_start = datetime.datetime.utcnow()
         state = self.instrument_query()
@@ -152,6 +165,7 @@ class Reaper(object):
             _id, item = _id_item
             log.info('reap queue   item %d of %d', i + 1, reap_queue_len)
             with tempfile.TemporaryDirectory(dir=self.tempdir) as tempdir:
+                self.before_reap(_id)
                 item['reaped'], metadata_map = self.reap(_id, item, tempdir)  # returns True, False, None
                 if item['reaped']:
                     item['failures'] = 0
@@ -165,6 +179,9 @@ class Reaper(object):
                         item['reaped'] = True
                         item['abandoned'] = True
                         log.warning('abandoning   ' + self.state_str(_id, item['state']))
+                if item['reaped'] :
+                    self.after_reap_success(_id)
+                self.after_reap(_id)
             self.persistent_state = self.state
 
     def run(self):

--- a/reaper/reaper.py
+++ b/reaper/reaper.py
@@ -101,7 +101,6 @@ class Reaper(object):
         # pylint: disable=missing-docstring
         pass
 
-
     def __get_instrument_state(self):
         query_start = datetime.datetime.utcnow()
         state = self.instrument_query()
@@ -179,7 +178,7 @@ class Reaper(object):
                         item['reaped'] = True
                         item['abandoned'] = True
                         log.warning('abandoning   ' + self.state_str(_id, item['state']))
-                if item['reaped'] :
+                if item['reaped']:
                     self.after_reap_success(_id)
                 self.after_reap(_id)
             self.persistent_state = self.state

--- a/reaper/reaper.py
+++ b/reaper/reaper.py
@@ -89,16 +89,30 @@ class Reaper(object):
         # pylint: disable=missing-docstring
         pass
 
+    def before_run(self):
+        """
+        Operations for before the run loop.
+        """
+        pass
+
     def before_reap(self, _id):
-        # pylint: disable=missing-docstring
+        """
+        Operations for before the series is reaped.
+        """
         pass
 
     def after_reap_success(self, _id):
-        # pylint: disable=missing-docstring
+        """
+        Operations after the series is reaped successfully.
+
+        Executed before after_reap()
+        """
         pass
 
     def after_reap(self, _id):
-        # pylint: disable=missing-docstring
+        """
+        Operations after the series is reaped, regardless of result.
+        """
         pass
 
     def __get_instrument_state(self):
@@ -185,6 +199,7 @@ class Reaper(object):
 
     def run(self):
         # pylint: disable=missing-docstring
+        self.before_run()
         self.__set_initial_state()
         while self.alive:
             if not self.in_working_hours:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_requires = [
 
 setup(
     name = 'reaper',
-    version = '1.0.1',
+    version = '1.0.2',
     description = 'SciTran Instrument Integration',
     author = 'Gunnar Schaefer',
     author_email = 'gsfr@stanford.edu',

--- a/test/install_deps.sh
+++ b/test/install_deps.sh
@@ -25,6 +25,9 @@ if [ ! -f "${ORTHANC_BUILD}/Orthanc" ]; then
   cd "$ORTHANC_BUILD"
   cmake -DSTATIC_BUILD=ON -DCMAKE_BUILD_TYPE=Release ../$ORTHANC_VERSION
   make
+else
+  cd "$ORTHANC_BUILD"
 fi
 
+make install
 )

--- a/test/install_deps.sh
+++ b/test/install_deps.sh
@@ -2,6 +2,8 @@
 
 set -u
 
+# DCMTK
+(
 if [ ! -f $DCMTK_VERSION/config/config.status ]; then
     curl http://dicom.offis.de/download/dcmtk/snapshot/old/$DCMTK_VERSION.tar.gz | tar xz
     cd $DCMTK_VERSION
@@ -13,3 +15,16 @@ else
 fi
 
 make install
+)
+
+# Orthanc
+(
+if [ ! -f "${ORTHANC_BUILD}/Orthanc" ]; then
+  curl http://www.orthanc-server.com/downloads/get.php?path=/orthanc/$ORTHANC_VERSION.tar.gz | tar xz
+  mkdir -p "$ORTHANC_BUILD"
+  cd "$ORTHANC_BUILD"
+  cmake -DSTATIC_BUILD=ON -DCMAKE_BUILD_TYPE=Release ../$ORTHANC_VERSION
+  make
+fi
+
+)

--- a/test/install_deps.sh
+++ b/test/install_deps.sh
@@ -22,7 +22,7 @@ make install
 if [ ! -f "$ORTHANC_VERSION/Orthanc" ]; then
   curl -L "http://www.orthanc-server.com/downloads/get.php?path=/orthanc/$ORTHANC_VERSION.tar.gz" | tar xz
   cd "$ORTHANC_VERSION"
-  cmake -DSTATIC_BUILD=ON -DCMAKE_BUILD_TYPE=Release
+  cmake -DCMAKE_INSTALL_PREFIX=$VIRTUAL_ENV -DSTATIC_BUILD=ON -DCMAKE_BUILD_TYPE=Release
   make
 else
   cd "$ORTHANC_VERSION"

--- a/test/install_deps.sh
+++ b/test/install_deps.sh
@@ -19,14 +19,13 @@ make install
 
 # Orthanc
 (
-if [ ! -f "${ORTHANC_BUILD}/Orthanc" ]; then
-  curl http://www.orthanc-server.com/downloads/get.php?path=/orthanc/$ORTHANC_VERSION.tar.gz | tar xz
-  mkdir -p "$ORTHANC_BUILD"
-  cd "$ORTHANC_BUILD"
-  cmake -DSTATIC_BUILD=ON -DCMAKE_BUILD_TYPE=Release ../$ORTHANC_VERSION
+if [ ! -f "$ORTHANC_VERSION/Orthanc" ]; then
+  curl -L "http://www.orthanc-server.com/downloads/get.php?path=/orthanc/$ORTHANC_VERSION.tar.gz" | tar xz
+  cd "$ORTHANC_VERSION"
+  cmake -DSTATIC_BUILD=ON -DCMAKE_BUILD_TYPE=Release
   make
 else
-  cd "$ORTHANC_BUILD"
+  cd "$ORTHANC_VERSION"
 fi
 
 make install

--- a/test/lint.sh
+++ b/test/lint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eu
+
+unset CDPATH
+cd "$( dirname "${BASH_SOURCE[0]}" )/.."
+
+echo "Running pylint ..."
+pylint --reports=no reaper
+
+echo
+
+echo "Running pep8 ..."
+pep8 --max-line-length=150 --ignore=E402 reaper

--- a/test/test.sh
+++ b/test/test.sh
@@ -7,6 +7,7 @@ cd "$( dirname "${BASH_SOURCE[0]}" )/.."
 
 DCMTK_DB_DIR=${DCMTK_DB_DIR:-"./dcmtk_dicom_db"}
 TESTDATA_DIR=${TESTDATA_DIR:-"./testdata"}
+ORTHANC_BUILD=${ORTHANC_BUILD:-"./Orthanc*Build"}
 
 PORT=${PORT:-"8027"}
 HOST=${HOST:-"http://localhost:$PORT"}
@@ -61,12 +62,20 @@ DCMQRSCP_PID=$!
 
 
 # Test DICOM Sniper
-dicom_sniper -y -k StudyID "" localhost 5104 3333 REAPER DCMQRSCP $HOST
+#dicom_sniper -y -k StudyID "" localhost 5104 3333 REAPER DCMQRSCP $HOST
 
 
 # Test DICOM Reaper
-dicom_reaper -o -s 1 $(mktemp) localhost 5104 3333 REAPER DCMQRSCP -u $HOST
+#dicom_reaper -o -s 1 $(mktemp) localhost 5104 3333 REAPER DCMQRSCP -u $HOST
 
 
 # Test Folder Sniper
-folder_sniper -y $TESTDATA_DIR $HOST
+#folder_sniper -y $TESTDATA_DIR $HOST
+
+# Test Orthanc DICOM Reaper
+"${ORTHANC_BUILD}/Orthanc" &
+ORTHANC_PID=$!
+sleep 5
+
+storescu -v -aec ORTHANC localhost 4242  $(find $TESTDATA_DIR -type d -name dicom | tail -n 1)
+orthanc_reaper -o -s 1 $(mktemp) localhost 4242 3333 REAPER ORTHANC "http://localhost:8042" -u $HOST

--- a/test/test.sh
+++ b/test/test.sh
@@ -16,7 +16,7 @@ HOST=${HOST:-"http://localhost:$PORT"}
 # Set up exit and error trap to shutdown dependencies
 shutdown() {
     echo 'Exit signal trapped'
-    kill $DCMQRSCP_PID $RECEIVER_PID
+    kill $DCMQRSCP_PID $RECEIVER_PID $ORTHANC_PID
     wait
 }
 trap "shutdown" EXIT ERR

--- a/test/test.sh
+++ b/test/test.sh
@@ -7,7 +7,6 @@ cd "$( dirname "${BASH_SOURCE[0]}" )/.."
 
 DCMTK_DB_DIR=${DCMTK_DB_DIR:-"./dcmtk_dicom_db"}
 TESTDATA_DIR=${TESTDATA_DIR:-"./testdata"}
-ORTHANC_BUILD=${ORTHANC_BUILD:-"./Orthanc*Build"}
 
 PORT=${PORT:-"8027"}
 HOST=${HOST:-"http://localhost:$PORT"}
@@ -73,7 +72,7 @@ dicom_reaper -o -s 1 $(mktemp) localhost 5104 3333 REAPER DCMQRSCP -u $HOST
 folder_sniper -y $TESTDATA_DIR $HOST
 
 # Test Orthanc DICOM Reaper
-ORTHANC_CONFIG_FILE="${ORTHANC_BUILD}/orthanc-config.json"
+ORTHANC_CONFIG_FILE="orthanc-config.json"
 cat << EOF > $ORTHANC_CONFIG_FILE
 {
   "DicomModalities" : {
@@ -82,7 +81,7 @@ cat << EOF > $ORTHANC_CONFIG_FILE
 }
 EOF
 
-"${ORTHANC_BUILD}/Orthanc" "${ORTHANC_CONFIG_FILE}" &
+Orthanc "${ORTHANC_CONFIG_FILE}" &
 ORTHANC_PID=$!
 sleep 5
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -77,5 +77,5 @@ DCMQRSCP_PID=$!
 ORTHANC_PID=$!
 sleep 5
 
-storescu -v -aec ORTHANC localhost 4242  $(find $TESTDATA_DIR -type d -name dicom | tail -n 1)
+storescu -v --scan-directories -aec ORTHANC localhost 4242  $(find $TESTDATA_DIR -type d -name dicom | tail -n 1)
 orthanc_reaper -o -s 1 $(mktemp) localhost 4242 3333 REAPER ORTHANC "http://localhost:8042" -u $HOST

--- a/test/test.sh
+++ b/test/test.sh
@@ -62,15 +62,15 @@ DCMQRSCP_PID=$!
 
 
 # Test DICOM Sniper
-#dicom_sniper -y -k StudyID "" localhost 5104 3333 REAPER DCMQRSCP $HOST
+dicom_sniper -y -k StudyID "" localhost 5104 3333 REAPER DCMQRSCP $HOST
 
 
 # Test DICOM Reaper
-#dicom_reaper -o -s 1 $(mktemp) localhost 5104 3333 REAPER DCMQRSCP -u $HOST
+dicom_reaper -o -s 1 $(mktemp) localhost 5104 3333 REAPER DCMQRSCP -u $HOST
 
 
 # Test Folder Sniper
-#folder_sniper -y $TESTDATA_DIR $HOST
+folder_sniper -y $TESTDATA_DIR $HOST
 
 # Test Orthanc DICOM Reaper
 ORTHANC_CONFIG_FILE="${ORTHANC_BUILD}/orthanc-config.json"

--- a/test/test.sh
+++ b/test/test.sh
@@ -73,7 +73,16 @@ DCMQRSCP_PID=$!
 #folder_sniper -y $TESTDATA_DIR $HOST
 
 # Test Orthanc DICOM Reaper
-"${ORTHANC_BUILD}/Orthanc" &
+ORTHANC_CONFIG_FILE="${ORTHANC_BUILD}/orthanc-config.json"
+cat << EOF > $ORTHANC_CONFIG_FILE
+{
+  "DicomModalities" : {
+    "reaper" : [ "REAPER", "127.0.0.1", 3333 ]
+  }
+}
+EOF
+
+"${ORTHANC_BUILD}/Orthanc" "${ORTHANC_CONFIG_FILE}" &
 ORTHANC_PID=$!
 sleep 5
 


### PR DESCRIPTION
Requires Orthanc DICOM server 1.0 with REST API.
- Introduces new tool `bin/orthanc_reaper` and includes additional positional parameter specifying the Orthanc REST API URI
- Introduces a set of virtual functions to reaper.py that other sub-classed tools can use as hooks to add functionality at predictable points of the reaper process.
  `before_run()`
  `before_reap()`
  `after_reap_success()`
  `after_reap()`
- Blocks all new stores into Orthanc DICOM server for the series being reaped during the C-MOVE, upload to scitran/core API, and deletion from Orthanc.

This approach breaks if there is more than one reaper or other client enabling/disabling stores on orthanc.
