### PR TITLE
Ability to specify external command to generate acquisition uid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 env:
     global:
         - DCMTK_VERSION="dcmtk-3.6.1_20150924"
-        - DCMTK_DB_DIR="dcmtk_dicom_db"
+        - DCMTK_DB_DIR="dcmtk_dicom_db-ci"
         - TESTDATA_DIR="testdata-ci"
         - ORTHANC_VERSION="Orthanc-1.1.0"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     global:
         - DCMTK_VERSION="dcmtk-3.6.1_20150924"
         - DCMTK_DB_DIR="dcmtk_dicom_db"
-        - TESTDATA_DIR="testdata"
+        - TESTDATA_DIR="testdata-ci"
         - ORTHANC_VERSION="Orthanc-1.1.0"
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
 
 script:
     - ./test/test.sh
-    - ./test/lint.sh reaper
+    - ./test/lint.sh
 
 after_success:
     - ./docker/build-trigger.sh Tag "${TRAVIS_TAG}" "${BUILD_TRIGGER_URL}"

--- a/reaper/dcm.py
+++ b/reaper/dcm.py
@@ -20,7 +20,10 @@ GEMS_TYPE_VXTL = ['DERIVED', 'SECONDARY', 'VXTL STATE']
 
 def __external_metadata(command, filepath):
     try:
-        return subprocess.check_output(shlex.split(command), filepath)
+        parms = shlex.split(command)
+        parms.append(filepath)
+        log.info(' command = %s', parms)
+        return subprocess.check_output(parms)
     except subprocess.CalledProcessError as ex:
         log.error('Error running external command. Exit %d', ex.returncode)
         return None

--- a/reaper/dcm.py
+++ b/reaper/dcm.py
@@ -1,7 +1,6 @@
 """SciTran Reaper DICOM utility functions"""
 
 import os
-import shutil
 import hashlib
 import logging
 import datetime

--- a/reaper/dcm.py
+++ b/reaper/dcm.py
@@ -20,10 +20,9 @@ GEMS_TYPE_VXTL = ['DERIVED', 'SECONDARY', 'VXTL STATE']
 
 def __external_metadata(command, filepath):
     try:
-        parms = shlex.split(command)
-        parms.append(filepath)
-        log.info(' command = %s', parms)
-        return subprocess.check_output(parms)
+        args = shlex.split(command) + [filepath]
+        log.debug('External metadata cmd: %s', ' '.join(args))
+        return subprocess.check_output(args)
     except subprocess.CalledProcessError as ex:
         log.error('Error running external command. Exit %d', ex.returncode)
         return None

--- a/reaper/dcm.py
+++ b/reaper/dcm.py
@@ -42,7 +42,6 @@ def pkg_series(_id, path, map_key, opt_key=None, anonymize=False, timezone=None,
         dir_name = name_prefix + '.' + FILETYPE
         arcdir_path = os.path.join(path, '..', dir_name)
         os.mkdir(arcdir_path)
-        first_file = None
         for filepath in acq_paths:
             dcm = DicomFile(filepath, map_key, opt_key, parse=True, anonymize=anonymize, timezone=timezone)
             filename = os.path.basename(filepath)
@@ -50,17 +49,15 @@ def pkg_series(_id, path, map_key, opt_key=None, anonymize=False, timezone=None,
                 filename = filename.replace('(none)', 'NA')
             file_time = max(int(dcm.acquisition_timestamp.strftime('%s')), 315561600)  # zip can't handle < 1980
             os.utime(filepath, (file_time, file_time))  # correct timestamps
-            new_filepath = '%s.dcm' % os.path.join(arcdir_path, filename)
-            os.rename(filepath, new_filepath)
-            if first_file is None:
-                first_file = new_filepath
+            arc_filepath = '%s.dcm' % os.path.join(arcdir_path, filename)
+            os.rename(filepath, arc_filepath)
         arc_path = util.create_archive(arcdir_path, dir_name)
         for md_group_info in (additional_metadata or {}).itervalues():
             for md_field, md_value in md_group_info.iteritems():
                 if md_value.startswith('^'):    # DICOM header value
                     md_group_info[md_field] = dcm.raw_header.get(md_value[1:], None)
                 elif md_value.startswith('@'):  # external command
-                    md_group_info[md_field] = __external_metadata(md_value[1:], first_file)
+                    md_group_info[md_field] = __external_metadata(md_value[1:], arc_filepath)
                 else:                           # verbatim value
                     md_group_info[md_field] = md_value[1:]
         metadata = util.object_metadata(dcm, timezone, os.path.basename(arc_path), additional_metadata)

--- a/reaper/dcm.py
+++ b/reaper/dcm.py
@@ -42,7 +42,6 @@ def pkg_series(_id, path, map_key, opt_key=None, anonymize=False, timezone=None)
         arc_path = util.create_archive(arcdir_path, dir_name)
         metadata = util.object_metadata(dcm, timezone, os.path.basename(arc_path))
         util.set_archive_metadata(arc_path, metadata)
-        shutil.rmtree(arcdir_path)
         metadata_map[arc_path] = metadata
     return metadata_map
 

--- a/reaper/dicom_reaper.py
+++ b/reaper/dicom_reaper.py
@@ -4,11 +4,11 @@ import os
 import logging
 import datetime
 import re
+from subprocess import Popen, PIPE, STDOUT
 
 from . import dcm
 from . import scu
 from . import reaper
-from subprocess import Popen, PIPE, STDOUT
 
 log = logging.getLogger('reaper.dicom')
 
@@ -86,28 +86,22 @@ class DicomReaper(reaper.Reaper):
         if self.uid_ext_command is None:
             return
         for filepath, metadata in metadata_map.iteritems():
-            print(filepath)
-            print(metadata)
             dcm_dir = re.sub(r'\.zip$', '', filepath)
 
             unzipped_file = [os.path.join(dcm_dir, filename) for filename in os.listdir(dcm_dir)][0]
 
             formatted_string = self.uid_ext_command.format(unzipped_file)
-            print(formatted_string)
-
             arg_list = formatted_string.split()
 
-            p = Popen(arg_list,
-                      stdout=PIPE,
-                      stderr=STDOUT)
-            out, _ = p.communicate()
+            proc = Popen(arg_list,
+                         stdout=PIPE,
+                         stderr=STDOUT)
+            out, _ = proc.communicate()
 
-            if p.returncode and p.returncode != 0:
-                log.error('Error with command. Return code = %d', p.returncode)
+            if proc.returncode and proc.returncode != 0:
+                log.error('Error with command. Return code = %d', proc.returncode)
                 raise RuntimeError(out)
-            print(out.rstrip())
             metadata['acquisition']['uid'] = out.rstrip()
-            print(metadata)
 
 
 def update_arg_parser(ap):

--- a/reaper/dicom_reaper.py
+++ b/reaper/dicom_reaper.py
@@ -4,7 +4,6 @@ import os
 import logging
 import datetime
 import re
-import zipfile
 
 from . import dcm
 from . import scu
@@ -89,28 +88,26 @@ class DicomReaper(reaper.Reaper):
         for filepath, metadata in metadata_map.iteritems():
             print(filepath)
             print(metadata)
-            dcm_dir = re.sub('\.zip$','',filepath)
+            dcm_dir = re.sub(r'\.zip$', '', filepath)
 
             unzipped_file = [os.path.join(dcm_dir, filename) for filename in os.listdir(dcm_dir)][0]
 
             formatted_string = self.uid_ext_command.format(unzipped_file)
             print(formatted_string)
 
-
             arg_list = formatted_string.split()
 
             p = Popen(arg_list,
-                       stdout=PIPE,
-                       stderr=STDOUT)
+                      stdout=PIPE,
+                      stderr=STDOUT)
             out, _ = p.communicate()
 
             if p.returncode and p.returncode != 0:
-                log.error('Error with command. Return code = {0}'.format(p.returncode))
+                log.error('Error with command. Return code = %d', p.returncode)
                 raise RuntimeError(out)
             print(out.rstrip())
             metadata['acquisition']['uid'] = out.rstrip()
             print(metadata)
-
 
 
 def update_arg_parser(ap):
@@ -122,7 +119,10 @@ def update_arg_parser(ap):
     ap.add_argument('aec', help='remote AE title')
 
     ap.add_argument('-A', '--no-anonymize', dest='anonymize', action='store_false', help='do not anonymize patient name and birthdate')
-    ap.add_argument('--uid-ext-command', dest='uid_ext_command', help='Command to execute against single source file to generate acquisition uid', default=None)
+    ap.add_argument('--uid-ext-command',
+                    dest='uid_ext_command',
+                    help='Command to execute against single source file to generate acquisition uid',
+                    default=None)
 
     return ap
 

--- a/reaper/util.py
+++ b/reaper/util.py
@@ -61,7 +61,7 @@ def hrsize(size):
     return '%.0f%sB' % (size, 'Y')
 
 
-def object_metadata(obj, timezone, filename):
+def object_metadata(obj, timezone, filename, additional_metadata=None):
     # pylint: disable=missing-docstring
     metadata = {
         'session': {'timezone': timezone},
@@ -75,6 +75,10 @@ def object_metadata(obj, timezone, filename):
     metadata['file']['name'] = filename
     metadata['session']['subject'] = metadata.pop('subject', {})
     metadata['acquisition']['files'] = [metadata.pop('file', {})]
+    for md_group, md_group_info in (additional_metadata or {}).iteritems():
+        metadata.setdefault(md_group, {})
+        metadata[md_group].setdefault('metadata', {})
+        metadata[md_group]['metadata'].update(md_group_info)
     return metadata
 
 

--- a/test/lint.sh
+++ b/test/lint.sh
@@ -6,9 +6,9 @@ unset CDPATH
 cd "$( dirname "${BASH_SOURCE[0]}" )/.."
 
 echo "Running pylint ..."
-pylint --reports=no "$@"
+pylint --reports=no reaper
 
 echo
 
 echo "Running pep8 ..."
-pep8 --max-line-length=150 --ignore=E402 "$@"
+pep8 --max-line-length=150 --ignore=E402 reaper

--- a/test/test.sh
+++ b/test/test.sh
@@ -29,7 +29,7 @@ RECEIVER_PID=$!
 # Fetch test data
 mkdir -p $TESTDATA_DIR
 if [ ! "$(ls -A $TESTDATA_DIR)" ]; then
-    curl -L https://github.com/scitran/testdata/archive/master.tar.gz | tar xz -C $TESTDATA_DIR --strip-components 1
+    curl -L https://github.com/scitran/testdata/archive/reaper-ci.tar.gz | tar xz -C $TESTDATA_DIR --strip-components 1
 fi
 
 


### PR DESCRIPTION
**Included in this PR**
- New option `uid_ext_command` to specify external command to run.
- Single non-deterministic file from acquisition source files will be used in the command.
- ~~Non-zero or empty string returned by command will prevent acquisition from being uploaded.~~
- Non-zero exit of external command will fail and abort reap attempt

**Actions Before Merge**
- [x] Create Proof Of Concept
- [ ] Decide final implementation details
- [ ] Add final implementation details here...
- [ ] Abort and fail reap attempt on external command error
