### PR TITLE
De-Identification fixes

### DIFF
--- a/bin/dicom_folder_sniper
+++ b/bin/dicom_folder_sniper
@@ -25,10 +25,11 @@ DEFAULT_FIELD_NAMES = {
     'session_label':        'StudyDescription',
     'acquisition_label':    'SeriesDescription',
     'dataset_label_prefix': 'SeriesNumber',
+    'exam_number':          'StudyID',
 }
 
 
-def scandir(path, group_related_series=False, symlinks=False, **kwargs):
+def scandir(path, group_related_series=False, symlinks=False, de_identify=False, **kwargs):
     field_names = DEFAULT_FIELD_NAMES
     field_names.update(kwargs)
 
@@ -56,8 +57,10 @@ def scandir(path, group_related_series=False, symlinks=False, **kwargs):
                 continue
 
             acq_uid = primary_series_uid if primary_series_uid and group_related_series else series_uid
-
-            subj_code = dcm.get_tag(field_names['subject_code'], 'Unknown')
+            if not de_identify:
+                subj_code = dcm.get_tag(field_names['subject_code'], 'Unknown')
+            else:
+                subj_code = 'ex' + dcm.get_tag(field_names['exam_number'], 'Unknown')
             sess_label = dcm.get_tag(field_names['session_label'], 'Untitled')
             acq_label = dcm.get_tag(field_names['acquisition_label'], 'Untitled')
             ds_label = dcm.get_tag(field_names['dataset_label_prefix'], 'Unknown') + ' - ' +  acq_label
@@ -185,7 +188,7 @@ def main():
 
     tag_override = {k: v if v.lower() != 'null' else None for k, v in args.tag_override}
 
-    sessions = scandir(args.path, args.group_related_series, args.symlinks, **tag_override)
+    sessions = scandir(args.path, args.group_related_series, args.symlinks, args.de_identify, **tag_override)
     emit_summary(sessions, args.group, args.project)
     if not args.yes:
         try:

--- a/bin/dicom_folder_sniper
+++ b/bin/dicom_folder_sniper
@@ -164,9 +164,9 @@ def main():
     auth_group.add_argument('--key', help='user API key')
     arg_parser.add_argument('--root', action='store_true', help='send API requests as site admin')
 
-    arg_parser.add_argument('--group-related-series', action='store_true', help='group derived Series into the same Acquisition')
-    arg_parser.add_argument('--de-identify', action='store_true', help='de-identify data before upload')
-    arg_parser.add_argument('--tag-override', nargs=2, action='append', default=[], help='DICOM tag override')
+    arg_parser.add_argument('--group_related_series', action='store_true', help='group derived Series into the same Acquisition')
+    arg_parser.add_argument('--de_identify', action='store_true', help='de-identify data before upload')
+    arg_parser.add_argument('--tag_override', nargs=2, action='append', default=[], help='DICOM tag override')
 
     args = arg_parser.parse_args(sys.argv[1:] or ['--help'])
 

--- a/bin/dicom_folder_sniper
+++ b/bin/dicom_folder_sniper
@@ -98,10 +98,8 @@ def emit_summary(sessions, project, group, de_identify=False):
                 file_cnt += len(ds['images'])
                 ds_cnt += 1
     log.warning('Found %d Acquisition(s) in %d Session(s)', acq_cnt, sess_cnt)
-    if de_identify:
-        log.warning('Will De-Identify and upload %d DICOM files as %d datasets', file_cnt, ds_cnt)
-    else:
-        log.warning('Will upload %d DICOM files as %d datasets', file_cnt, ds_cnt)
+    action = 'de-identify and upload' if de_identify else 'upload'
+    log.warning('Will %s %d DICOM files as %d datasets', action, file_cnt, ds_cnt)
 
     if log.isEnabledFor(logging.INFO):
         log.info('\nDerived hierarchy')

--- a/bin/dicom_folder_sniper
+++ b/bin/dicom_folder_sniper
@@ -88,7 +88,7 @@ def scandir(path, group_related_series=False, de_identify=False, symlinks=False,
     return sessions
 
 
-def emit_summary(sessions, project, group):
+def emit_summary(sessions, project, group, de_identify=False):
     sess_cnt = len(sessions)
     acq_cnt = sum([len(sess['acquisitions']) for sess in sessions.itervalues()])
     file_cnt = ds_cnt = 0
@@ -98,7 +98,10 @@ def emit_summary(sessions, project, group):
                 file_cnt += len(ds['images'])
                 ds_cnt += 1
     log.warning('Found %d Acquisition(s) in %d Session(s)', acq_cnt, sess_cnt)
-    log.warning('Will upload %d DICOM files as %d datasets', file_cnt, ds_cnt)
+    if de_identify:
+        log.warning('Will De-Identify and upload %d DICOM files as %d datasets', file_cnt, ds_cnt)
+    else:
+        log.warning('Will upload %d DICOM files as %d datasets', file_cnt, ds_cnt)
 
     if log.isEnabledFor(logging.INFO):
         log.info('\nDerived hierarchy')
@@ -189,7 +192,7 @@ def main():
     tag_override = {k: v if v.lower() != 'null' else None for k, v in args.tag_override}
 
     sessions = scandir(args.path, args.group_related_series, args.de_identify, args.symlinks, **tag_override)
-    emit_summary(sessions, args.group, args.project)
+    emit_summary(sessions, args.group, args.project, args.de_identify)
     if not args.yes:
         try:
             raw_input('Press Enter to process and upload all data or Ctrl-C to abort...')

--- a/bin/dicom_folder_sniper
+++ b/bin/dicom_folder_sniper
@@ -29,7 +29,7 @@ DEFAULT_FIELD_NAMES = {
 }
 
 
-def scandir(path, group_related_series=False, symlinks=False, de_identify=False, **kwargs):
+def scandir(path, group_related_series=False, de_identify=False, symlinks=False, **kwargs):
     field_names = DEFAULT_FIELD_NAMES
     field_names.update(kwargs)
 
@@ -60,7 +60,7 @@ def scandir(path, group_related_series=False, symlinks=False, de_identify=False,
             if not de_identify:
                 subj_code = dcm.get_tag(field_names['subject_code'], 'Unknown')
             else:
-                subj_code = 'ex' + dcm.get_tag(field_names['exam_number'], 'Unknown')
+                subj_code = 'ex' + dcm.get_tag(field_names['exam_number'], '0')
             sess_label = dcm.get_tag(field_names['session_label'], 'Untitled')
             acq_label = dcm.get_tag(field_names['acquisition_label'], 'Untitled')
             ds_label = dcm.get_tag(field_names['dataset_label_prefix'], 'Unknown') + ' - ' +  acq_label
@@ -164,9 +164,9 @@ def main():
     auth_group.add_argument('--key', help='user API key')
     arg_parser.add_argument('--root', action='store_true', help='send API requests as site admin')
 
-    arg_parser.add_argument('--group_related_series', action='store_true', help='group derived Series into the same Acquisition')
-    arg_parser.add_argument('--de_identify', action='store_true', help='de-identify data before upload')
-    arg_parser.add_argument('--tag_override', nargs=2, action='append', default=[], help='DICOM tag override')
+    arg_parser.add_argument('--group-related-series', action='store_true', help='group derived Series into the same Acquisition')
+    arg_parser.add_argument('--de-identify', action='store_true', help='de-identify data before upload')
+    arg_parser.add_argument('--tag-override', nargs=2, action='append', default=[], help='DICOM tag override')
 
     args = arg_parser.parse_args(sys.argv[1:] or ['--help'])
 
@@ -188,7 +188,7 @@ def main():
 
     tag_override = {k: v if v.lower() != 'null' else None for k, v in args.tag_override}
 
-    sessions = scandir(args.path, args.group_related_series, args.symlinks, args.de_identify, **tag_override)
+    sessions = scandir(args.path, args.group_related_series, args.de_identify, args.symlinks, **tag_override)
     emit_summary(sessions, args.group, args.project)
     if not args.yes:
         try:

--- a/reaper/dcm.py
+++ b/reaper/dcm.py
@@ -104,9 +104,9 @@ class DicomFile(object):
                 if dob and study_datetime:
                     months = 12 * (study_datetime.year - dob.year) + (study_datetime.month - dob.month) - (study_datetime.day < dob.day)
                     dcm.PatientAge = '%03dM' % months if months < 960 else '%03dY' % (months / 12)
-            dcm.pop('PatientBirthDate', None)
-            dcm.pop('PatientName', None)
-            dcm.pop('PatientID', None)
+            dcm.PatientBirthDate = ''
+            dcm.PatientName = ''
+            dcm.PatientID = ''
             dcm.save_as(filepath)
 
     def get_tag(self, tag_name, default=None):

--- a/reaper/dcm.py
+++ b/reaper/dcm.py
@@ -104,9 +104,9 @@ class DicomFile(object):
                 if dob and study_datetime:
                     months = 12 * (study_datetime.year - dob.year) + (study_datetime.month - dob.month) - (study_datetime.day < dob.day)
                     dcm.PatientAge = '%03dM' % months if months < 960 else '%03dY' % (months / 12)
-            dcm.PatientBirthDate = ''
-            dcm.PatientName = ''
-            dcm.PatientID = ''
+            del dcm.PatientBirthDate
+            del dcm.PatientName
+            del dcm.PatientID
             dcm.save_as(filepath)
 
     def get_tag(self, tag_name, default=None):

--- a/reaper/upload.py
+++ b/reaper/upload.py
@@ -4,9 +4,9 @@ import os
 import json
 import array
 import logging
-import httplib
 import datetime
 
+import httplib
 import requests
 import requests_toolbelt
 
@@ -118,7 +118,7 @@ def __http_upload(url, secret_info, key, root, insecure, upload_route):
 def __request_session(secret_info, key, root, insecure):
     # pylint: disable=missing-docstring
     if insecure:
-        requests.packages.urllib3.disable_warnings()
+        requests.urllib3.disable_warnings()
     rs = requests.Session()
     if secret_info:
         rs.headers['X-SciTran-Method'] = secret_info[0]

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ import os
 from setuptools import setup, find_packages
 
 install_requires = [
-    'pydicom',
-    'python-dateutil',
-    'pytz',
-    'requests',
-    'requests_toolbelt',
-    'tzlocal',
+    'pydicom==0.9.9',
+    'python-dateutil==2.6.0',
+    'pytz==2017.2',
+    'requests==2.17.3',
+    'requests_toolbelt==0.8.0',
+    'tzlocal==1.4',
 ]
 
 setup(

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,3 +1,3 @@
-pep8
-pylint
-uwsgi
+pep8==1.7.0
+pylint==1.7.1
+uwsgi==2.0.15


### PR DESCRIPTION
1. 0bd0b5b IMO, and my use case, when the `--de_identify` option is used we don't want the `PatientID` used for the subject_code as it sometimes contains SSNs 😱  
2. b9dfcd4 The arg_parser arg for `--de-identify` was not working, as it was referenced in the code as `de_identify`. Others fixed as well. 
3. 3c9ecd3 These fields were not being removed using `dcm.pop`. I didn't investigate further since setting them to empty strings suited my use case. 

