### PR TITLE
Dicom folder sniper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ before_install:
     - ln -s bin $VIRTUAL_ENV/sbin
 
 install:
-    - pip install .
     - pip install -r test/requirements.txt
+    - pip install .
     - ./test/install_deps.sh
 
 script:

--- a/bin/dicom_folder_sniper
+++ b/bin/dicom_folder_sniper
@@ -5,11 +5,13 @@
 
 import os
 import sys
+import shutil
 import logging
 import argparse
 
-import dicom
+import dicom # FIXME should use reaper.dcm instead
 
+import reaper.dcm
 import reaper.util
 import reaper.upload
 import reaper.tempdir as tempfile
@@ -99,7 +101,7 @@ def emit_summary(sessions, project, group):
         log.info('')
 
 
-def upload(sessions, group, project, upload_function):
+def upload(sessions, group, project, upload_function, de_identify=False):
     metadata = {}
     metadata['group'] = {'_id': group}
     metadata['project'] = {'label': project}
@@ -114,10 +116,18 @@ def upload(sessions, group, project, upload_function):
             metadata['acquisition']['label'] = acq['label']
             for ds in acq['datasets'].itervalues():
                 with tempfile.TemporaryDirectory() as tempdir:
-                    paths = [path for path in ds['images'].itervalues()]
+                    if de_identify:
+                        paths = []
+                        log.info('De-id\'ing    %s', ds['label'])
+                        for filepath in ds['images'].itervalues():
+                            newpath = os.path.join(tempdir, os.path.basename(filepath))
+                            paths.append(newpath)
+                            shutil.copyfile(filepath, newpath)
+                            reaper.dcm.DicomFile(newpath, de_identify=True)
+                    else:
+                        paths = [path for path in ds['images'].itervalues()]
                     archive = reaper.util.create_archive(paths, ds['label'], outdir=tempdir)
-                    archive_name = os.path.basename(archive)
-                    metadata['acquisition']['files'] = [{'type': 'dicom', 'name': archive_name}]
+                    metadata['acquisition']['files'] = [{'type': 'dicom', 'name': os.path.basename(archive)}]
                     reaper.upload.metadata_upload(archive, metadata, upload_function)
 
 
@@ -132,6 +142,7 @@ def main():
     arg_parser.add_argument('group', help='Group ID')
     arg_parser.add_argument('project', help='Project Name')
     arg_parser.add_argument('-g', '--group-series', action='store_true', help='group derived Series into the same Acquisition')
+    arg_parser.add_argument('-d', '--de-identify', action='store_true', help='de-identify data before upload')
     arg_parser.add_argument('-i', '--insecure', action='store_true', help='do not verify server SSL certificates')
     arg_parser.add_argument('-y', '--yes', action='store_true', help='do not prompt to continue')
     arg_parser.add_argument('-l', '--loglevel', default='warning', help='log level [INFO]')
@@ -166,7 +177,7 @@ def main():
 
     try:
         #upsert_groups(groups, api_request) FIXME check for write access to project
-        upload(sessions, args.group, args.project, upload_function)
+        upload(sessions, args.group, args.project, upload_function, args.de_identify)
     except Exception as ex:
         log.critical(str(ex))
         sys.exit(1)
@@ -174,7 +185,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-
-
-## FIXME SeriesDescription of derived series is lost
-## FIXME What do we use for the filename? SeriesNumber or SeriesNumber + SeriesDescription?

--- a/bin/dicom_folder_sniper
+++ b/bin/dicom_folder_sniper
@@ -25,10 +25,11 @@ DEFAULT_FIELD_NAMES = {
     'session_label':        'StudyDescription',
     'acquisition_label':    'SeriesDescription',
     'dataset_label_prefix': 'SeriesNumber',
+    'exam_number':          'StudyID',
 }
 
 
-def scandir(path, group_related_series=False, symlinks=False, **kwargs):
+def scandir(path, group_related_series=False, symlinks=False, de_identify=False, **kwargs):
     field_names = DEFAULT_FIELD_NAMES
     field_names.update(kwargs)
 
@@ -56,8 +57,10 @@ def scandir(path, group_related_series=False, symlinks=False, **kwargs):
                 continue
 
             acq_uid = primary_series_uid if primary_series_uid and group_related_series else series_uid
-
-            subj_code = dcm.get_tag(field_names['subject_code'], 'Unknown')
+            if not de_identify:
+                subj_code = dcm.get_tag(field_names['subject_code'], 'Unknown')
+            else:
+                subj_code = 'ex' + dcm.get_tag(field_names['exam_number'], 'Unknown')
             sess_label = dcm.get_tag(field_names['session_label'], 'Untitled')
             acq_label = dcm.get_tag(field_names['acquisition_label'], 'Untitled')
             ds_label = dcm.get_tag(field_names['dataset_label_prefix'], 'Unknown') + ' - ' +  acq_label
@@ -185,7 +188,7 @@ def main():
 
     tag_override = {k: v if v.lower() != 'null' else None for k, v in args.tag_override}
 
-    sessions = scandir(args.path, args.group_related_series, args.symlinks, **tag_override)
+    sessions = scandir(args.path, args.group_related_series, args.symlinks, args.de_identify, **tag_override)
     emit_summary(sessions, args.group, args.project)
     if not args.yes:
         try:

--- a/bin/dicom_folder_sniper
+++ b/bin/dicom_folder_sniper
@@ -181,7 +181,7 @@ def main():
         sys.exit(1)
 
     secret_info = ('DICOM Folder Sniper', 'System Import', args.secret) if args.secret else None
-    api_request, upload_function = reaper.upload.upload_function(args.uri, secret_info, args.key, args.root, args.insecure, '/upload/label')
+    api_request, upload_function = reaper.upload.upload_function(args.uri, secret_info, args.key, args.root, args.insecure, '/api/upload/uid')
 
     tag_override = {k: v if v.lower() != 'null' else None for k, v in args.tag_override}
 

--- a/bin/dicom_folder_sniper
+++ b/bin/dicom_folder_sniper
@@ -1,0 +1,177 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# vim: filetype=python
+
+import os
+import sys
+import copy
+import json
+import logging
+import argparse
+
+import dicom
+
+import reaper.util
+import reaper.upload
+import reaper.tempdir as tempfile
+
+logging.basicConfig(
+    format='%(message)s',
+)
+log = logging.getLogger()
+
+
+def scandir(path, group_derived_series=False, symlinks=False):
+    log.info('Scanning subfolders')
+    sessions = {}
+
+    for dirpath, dirnames, filenames in os.walk(path, followlinks=symlinks):
+        dirnames[:] = [dn for dn in dirnames if not dn.startswith('.')] # use slice assignment to influence walk
+        filepaths = [os.path.join(dirpath, fn) for fn in filenames if not fn.startswith('.')] # ignore dotfiles
+        log.info('  %s', os.path.relpath(dirpath, path))
+
+        for fp in filepaths:
+            try:
+                dcm = dicom.read_file(fp, stop_before_pixels=True)
+            except dicom.errors.InvalidDicomError:
+                log.info('    Ignoring non-DICOM file %s', fp)
+                continue
+
+            try:
+                study_uid = dcm.StudyInstanceUID
+                series_uid = dcm.SeriesInstanceUID
+                primary_series_uid = dcm.get('RelatedSeriesSequence', [{}])[0].get('SeriesInstanceUID')
+                image_uid = dcm.SOPInstanceUID
+            except AttributeError:
+                log.warning('%s does not contain all required DICOM UIDs - skipping', fp)
+                continue
+
+            acq_uid = primary_series_uid if primary_series_uid and group_derived_series else series_uid
+
+            subj_id = dcm.get('PatientID') or 'Unknown'
+            sess_label = dcm.get('StudyDescription') or dcm.get('ProtocolName') or 'Untitled'
+            acq_label = dcm.get('SeriesDescription') or 'Untitled'
+            ds_label = (str(dcm.get('SeriesNumber')) or 'Untitled') + (' - ' +  acq_label if group_derived_series else '')
+
+            sess = sessions.setdefault(study_uid, {
+                'subject': subj_id,
+                'label': sess_label,
+                'acquisitions': {},
+            })
+            acq = sess['acquisitions'].setdefault(acq_uid, {
+                'label': acq_label,
+                'datasets': {},
+            })
+            ds = acq['datasets'].setdefault(series_uid, {
+                'type': dcm.get('ImageType'), # for debug purposes only
+                'label': ds_label,
+                'images': {},
+            })
+            ds['images'][image_uid] = fp
+
+            if group_derived_series and not primary_series_uid:
+                acq['label'] = acq_label # force the label for primary series
+
+    return sessions
+
+
+def emit_summary(sessions):
+    sess_cnt = len(sessions)
+    acq_cnt = sum([len(sess['acquisitions']) for sess in sessions.itervalues()])
+    file_cnt = ds_cnt = 0
+    for sess in sessions.itervalues():
+        for acq in sess['acquisitions'].itervalues():
+            for ds in acq['datasets'].itervalues():
+                file_cnt += len(ds['images'])
+                ds_cnt += 1
+    log.info('Found %d Acquisition(s) in %d Session(s)', acq_cnt, sess_cnt)
+    log.info('Will upload %d DICOM files as %d datasets', file_cnt, ds_cnt)
+
+    if log.isEnabledFor(logging.DEBUG):
+        sessions = copy.deepcopy(sessions)
+        for sess in sessions.itervalues():
+            for acq in sess['acquisitions'].itervalues():
+                for ds in acq['datasets'].itervalues():
+                    ds['images'] = len(ds['images'])
+        log.debug('\n%s\n', json.dumps(sessions, indent=4, separators=(',', ': '), sort_keys=True))
+
+
+def upload(sessions, group, project, upload_function):
+    metadata = {}
+    metadata['group'] = {'_id': group}
+    metadata['project'] = {'label': project}
+    for sess in sessions.itervalues():
+        metadata['session'] = {}
+        metadata['session']['label'] = sess['label']
+        metadata['session']['subject'] = sess['subject']
+        for acq in sess['acquisitions'].itervalues():
+            metadata['acquisition'] = {}
+            metadata['acquisition']['label'] = acq['label']
+            metadata['acquisition']['files'] = {'type': 'dicom'}
+            for ds in acq['datasets'].itervalues():
+                metadata['acquisition']['files']['name'] = ds['label']
+                print group, project, sess['label'], sess['subject'], acq['label'], ds['label']
+                with tempfile.TemporaryDirectory() as tempdir:
+                    paths = [path for path in ds['images'].itervalues()]
+                    archive = reaper.util.create_archive(paths, ds['label'], outdir=tempdir)
+                    upload_function(archive, metadata)
+
+
+DESCRIPTION = u"""
+"""
+
+
+def main():
+    arg_parser = argparse.ArgumentParser(description=DESCRIPTION, formatter_class=argparse.RawDescriptionHelpFormatter)
+    arg_parser.add_argument('path', help='path to reap')
+    arg_parser.add_argument('uri', help='API URL')
+    arg_parser.add_argument('group', help='Group ID')
+    arg_parser.add_argument('project', help='Project Name')
+    arg_parser.add_argument('-g', '--group-series', action='store_true', help='group derived Series into the same Acquisition')
+    arg_parser.add_argument('-i', '--insecure', action='store_true', help='do not verify server SSL certificates')
+    arg_parser.add_argument('-y', '--yes', action='store_true', help='do not prompt to continue')
+    arg_parser.add_argument('-l', '--loglevel', default='info', help='log level [INFO]')
+    arg_parser.add_argument('-s', '--symlinks', action='store_true', help='follow symbolic links that resolve to directories')
+    arg_parser.add_argument('--root', action='store_true', help='send API requests as site admin')
+
+    auth_group = arg_parser.add_mutually_exclusive_group()
+    auth_group.add_argument('--secret', help='shared API secret')
+    auth_group.add_argument('--key', help='user API key')
+
+    args = arg_parser.parse_args(sys.argv[1:] or ['--help'])
+
+    log.setLevel(getattr(logging, args.loglevel.upper()))
+    log.debug(args)
+
+    args.path = os.path.expanduser(args.path)
+    if not os.path.isdir(args.path):
+        log.error('Path        %s is not a directory or does not exist', args.path)
+        sys.exit(1)
+
+    secret_info = ('DICOM Folder Sniper', 'System Import', args.secret) if args.secret else None
+    api_request, upload_function = reaper.upload.upload_function(args.uri, secret_info, args.key, args.root, args.insecure, '/upload/label')
+
+    sessions = scandir(args.path, args.group_series, args.symlinks)
+    emit_summary(sessions)
+    if not args.yes:
+        try:
+            raw_input('\nPress Enter to process and upload all data or Ctrl-C to abort...')
+        except KeyboardInterrupt:
+            print
+            sys.exit(1)
+
+    try:
+        #upsert_groups(groups, api_request) FIXME check for write access to project
+        upload(sessions, args.group, args.project, upload_function)
+    except Exception as ex:
+        log.critical(str(ex))
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()
+
+
+## FIXME SeriesDescription of derived series is lost
+## FIXME What do we use for the filename? SeriesNumber or SeriesNumber + SeriesDescription?

--- a/bin/dicom_folder_sniper
+++ b/bin/dicom_folder_sniper
@@ -164,9 +164,9 @@ def main():
     auth_group.add_argument('--key', help='user API key')
     arg_parser.add_argument('--root', action='store_true', help='send API requests as site admin')
 
-    arg_parser.add_argument('--group-related-series', action='store_true', help='group derived Series into the same Acquisition')
-    arg_parser.add_argument('--de-identify', action='store_true', help='de-identify data before upload')
-    arg_parser.add_argument('--tag-override', nargs=2, action='append', default=[], help='DICOM tag override')
+    arg_parser.add_argument('--group_related_series', action='store_true', help='group derived Series into the same Acquisition')
+    arg_parser.add_argument('--de_identify', action='store_true', help='de-identify data before upload')
+    arg_parser.add_argument('--tag_override', nargs=2, action='append', default=[], help='DICOM tag override')
 
     args = arg_parser.parse_args(sys.argv[1:] or ['--help'])
 

--- a/bin/dicom_folder_sniper
+++ b/bin/dicom_folder_sniper
@@ -109,7 +109,7 @@ def emit_summary(sessions, project, group):
         log.info('')
 
 
-def upload(sessions, group, project, upload_function, de_identify=False):
+def upload(sessions, group, project, upload_function, de_identify=False, timezone=None):
     metadata = {}
     metadata['group'] = {'_id': group}
     metadata['project'] = {'label': project}
@@ -131,9 +131,10 @@ def upload(sessions, group, project, upload_function, de_identify=False):
                             newpath = os.path.join(tempdir, os.path.basename(filepath))
                             paths.append(newpath)
                             shutil.copyfile(filepath, newpath)
-                            reaper.dcm.DicomFile(newpath, de_identify=True)
+                            reaper.dcm.DicomFile(newpath, de_identify=True, timezone=timezone)
                     else:
                         paths = [path for path in ds['images'].itervalues()]
+                    log.info('Packaging    %s', ds['label'])
                     archive = reaper.util.create_archive(paths, ds['label'], outdir=tempdir)
                     metadata['acquisition']['files'] = [{'type': 'dicom', 'name': os.path.basename(archive)}]
                     reaper.upload.metadata_upload(archive, metadata, upload_function)
@@ -151,6 +152,7 @@ def main():
     arg_parser.add_argument('project', help='Project Name')
     arg_parser.add_argument('-i', '--insecure', action='store_true', help='do not verify server SSL certificates')
     arg_parser.add_argument('-y', '--yes', action='store_true', help='do not prompt to continue')
+    arg_parser.add_argument('-z', '--timezone', help='instrument timezone [system timezone]')
     arg_parser.add_argument('-l', '--loglevel', default='warning', help='log level [INFO]')
     arg_parser.add_argument('-s', '--symlinks', action='store_true', help='follow symbolic links that resolve to directories')
     arg_parser.add_argument('--root', action='store_true', help='send API requests as site admin')
@@ -167,6 +169,11 @@ def main():
 
     log.setLevel(getattr(logging, args.loglevel.upper()))
     log.debug('Parsed arguments:\n%s\n', vars(args))
+
+    args.timezone = reaper.util.validate_timezone(args.timezone)
+    if args.timezone is None:
+        log.error('invalid timezone')
+        sys.exit(1)
 
     args.path = os.path.expanduser(args.path)
     if not os.path.isdir(args.path):
@@ -190,9 +197,10 @@ def main():
 
     try:
         #upsert_groups(groups, api_request) FIXME check for write access to project
-        upload(sessions, args.group, args.project, upload_function, args.de_identify)
+        upload(sessions, args.group, args.project, upload_function, args.de_identify, args.timezone)
     except Exception as ex:
         log.critical(str(ex))
+        log.critical('Unexpected error - bailing out')
         sys.exit(1)
 
 

--- a/bin/dicom_folder_sniper
+++ b/bin/dicom_folder_sniper
@@ -153,13 +153,13 @@ def main():
     arg_parser.add_argument('-i', '--insecure', action='store_true', help='do not verify server SSL certificates')
     arg_parser.add_argument('-y', '--yes', action='store_true', help='do not prompt to continue')
     arg_parser.add_argument('-z', '--timezone', help='instrument timezone [system timezone]')
-    arg_parser.add_argument('-l', '--loglevel', default='warning', help='log level [INFO]')
+    arg_parser.add_argument('-l', '--loglevel', default='warning', help='log level [WARNING]')
     arg_parser.add_argument('-s', '--symlinks', action='store_true', help='follow symbolic links that resolve to directories')
-    arg_parser.add_argument('--root', action='store_true', help='send API requests as site admin')
 
     auth_group = arg_parser.add_mutually_exclusive_group()
     auth_group.add_argument('--secret', help='shared API secret')
     auth_group.add_argument('--key', help='user API key')
+    arg_parser.add_argument('--root', action='store_true', help='send API requests as site admin')
 
     arg_parser.add_argument('--group-related-series', action='store_true', help='group derived Series into the same Acquisition')
     arg_parser.add_argument('--de-identify', action='store_true', help='de-identify data before upload')

--- a/bin/dicom_folder_sniper
+++ b/bin/dicom_folder_sniper
@@ -5,8 +5,6 @@
 
 import os
 import sys
-import copy
-import json
 import logging
 import argparse
 
@@ -23,7 +21,7 @@ log = logging.getLogger()
 
 
 def scandir(path, group_derived_series=False, symlinks=False):
-    log.info('Scanning subfolders')
+    log.warning('Scanning subfolders')
     sessions = {}
 
     for dirpath, dirnames, filenames in os.walk(path, followlinks=symlinks):
@@ -52,7 +50,7 @@ def scandir(path, group_derived_series=False, symlinks=False):
             subj_id = dcm.get('PatientID') or 'Unknown'
             sess_label = dcm.get('StudyDescription') or dcm.get('ProtocolName') or 'Untitled'
             acq_label = dcm.get('SeriesDescription') or 'Untitled'
-            ds_label = (str(dcm.get('SeriesNumber')) or 'Untitled') + (' - ' +  acq_label if group_derived_series else '')
+            ds_label = (str(dcm.get('SeriesNumber')) or 'Unknown') + ' - ' +  acq_label
 
             sess = sessions.setdefault(study_uid, {
                 'subject': subj_id,
@@ -73,10 +71,11 @@ def scandir(path, group_derived_series=False, symlinks=False):
             if group_derived_series and not primary_series_uid:
                 acq['label'] = acq_label # force the label for primary series
 
+    log.info('')
     return sessions
 
 
-def emit_summary(sessions):
+def emit_summary(sessions, project, group):
     sess_cnt = len(sessions)
     acq_cnt = sum([len(sess['acquisitions']) for sess in sessions.itervalues()])
     file_cnt = ds_cnt = 0
@@ -85,37 +84,41 @@ def emit_summary(sessions):
             for ds in acq['datasets'].itervalues():
                 file_cnt += len(ds['images'])
                 ds_cnt += 1
-    log.info('Found %d Acquisition(s) in %d Session(s)', acq_cnt, sess_cnt)
-    log.info('Will upload %d DICOM files as %d datasets', file_cnt, ds_cnt)
+    log.warning('Found %d Acquisition(s) in %d Session(s)', acq_cnt, sess_cnt)
+    log.warning('Will upload %d DICOM files as %d datasets', file_cnt, ds_cnt)
 
-    if log.isEnabledFor(logging.DEBUG):
-        sessions = copy.deepcopy(sessions)
+    if log.isEnabledFor(logging.INFO):
+        log.info('\nEstablished hierarchy:')
+        log.info('%s\n  %s', project, group)
         for sess in sessions.itervalues():
+            log.info('    ' + sess['label'])
             for acq in sess['acquisitions'].itervalues():
+                log.info('      ' + acq['label'])
                 for ds in acq['datasets'].itervalues():
-                    ds['images'] = len(ds['images'])
-        log.debug('\n%s\n', json.dumps(sessions, indent=4, separators=(',', ': '), sort_keys=True))
+                    log.info('        %s (%d images)', ds['label'], len(ds['images']))
+        log.info('')
 
 
 def upload(sessions, group, project, upload_function):
     metadata = {}
     metadata['group'] = {'_id': group}
     metadata['project'] = {'label': project}
-    for sess in sessions.itervalues():
+    for sid, sess in sessions.iteritems():
         metadata['session'] = {}
+        metadata['session']['uid'] = sid
         metadata['session']['label'] = sess['label']
-        metadata['session']['subject'] = sess['subject']
-        for acq in sess['acquisitions'].itervalues():
+        metadata['session']['subject'] = {'code': sess['subject']}
+        for aid, acq in sess['acquisitions'].iteritems():
             metadata['acquisition'] = {}
+            metadata['acquisition']['uid'] = aid
             metadata['acquisition']['label'] = acq['label']
-            metadata['acquisition']['files'] = {'type': 'dicom'}
             for ds in acq['datasets'].itervalues():
-                metadata['acquisition']['files']['name'] = ds['label']
-                print group, project, sess['label'], sess['subject'], acq['label'], ds['label']
                 with tempfile.TemporaryDirectory() as tempdir:
                     paths = [path for path in ds['images'].itervalues()]
                     archive = reaper.util.create_archive(paths, ds['label'], outdir=tempdir)
-                    upload_function(archive, metadata)
+                    archive_name = os.path.basename(archive)
+                    metadata['acquisition']['files'] = [{'type': 'dicom', 'name': archive_name}]
+                    reaper.upload.metadata_upload(archive, metadata, upload_function)
 
 
 DESCRIPTION = u"""
@@ -131,7 +134,7 @@ def main():
     arg_parser.add_argument('-g', '--group-series', action='store_true', help='group derived Series into the same Acquisition')
     arg_parser.add_argument('-i', '--insecure', action='store_true', help='do not verify server SSL certificates')
     arg_parser.add_argument('-y', '--yes', action='store_true', help='do not prompt to continue')
-    arg_parser.add_argument('-l', '--loglevel', default='info', help='log level [INFO]')
+    arg_parser.add_argument('-l', '--loglevel', default='warning', help='log level [INFO]')
     arg_parser.add_argument('-s', '--symlinks', action='store_true', help='follow symbolic links that resolve to directories')
     arg_parser.add_argument('--root', action='store_true', help='send API requests as site admin')
 
@@ -142,7 +145,7 @@ def main():
     args = arg_parser.parse_args(sys.argv[1:] or ['--help'])
 
     log.setLevel(getattr(logging, args.loglevel.upper()))
-    log.debug(args)
+    log.debug('Parsed arguments:\n%s\n', vars(args))
 
     args.path = os.path.expanduser(args.path)
     if not os.path.isdir(args.path):
@@ -153,10 +156,10 @@ def main():
     api_request, upload_function = reaper.upload.upload_function(args.uri, secret_info, args.key, args.root, args.insecure, '/upload/label')
 
     sessions = scandir(args.path, args.group_series, args.symlinks)
-    emit_summary(sessions)
+    emit_summary(sessions, args.group, args.project)
     if not args.yes:
         try:
-            raw_input('\nPress Enter to process and upload all data or Ctrl-C to abort...')
+            raw_input('Press Enter to process and upload all data or Ctrl-C to abort...')
         except KeyboardInterrupt:
             print
             sys.exit(1)

--- a/bin/dicom_folder_sniper
+++ b/bin/dicom_folder_sniper
@@ -98,10 +98,8 @@ def emit_summary(sessions, project, group, de_identify=False):
                 file_cnt += len(ds['images'])
                 ds_cnt += 1
     log.warning('Found %d Acquisition(s) in %d Session(s)', acq_cnt, sess_cnt)
-    if de_identify:
-        log.warning('Will De-Identify and upload %d DICOM files as %d datasets', file_cnt, ds_cnt)
-    else:
-        log.warning('Will upload %d DICOM files as %d datasets', file_cnt, ds_cnt)
+    action = 'de-identify and upload' if de_identify else 'upload'
+    log.warning('Will %s %d DICOM files as %d datasets', action, file_cnt, ds_cnt)
 
     if log.isEnabledFor(logging.INFO):
         log.info('\nDerived hierarchy')

--- a/bin/dicom_folder_sniper
+++ b/bin/dicom_folder_sniper
@@ -28,7 +28,7 @@ DEFAULT_FIELD_NAMES = {
 }
 
 
-def scandir(path, group_derived_series=False, symlinks=False, **kwargs):
+def scandir(path, group_related_series=False, symlinks=False, **kwargs):
     field_names = DEFAULT_FIELD_NAMES
     field_names.update(kwargs)
 
@@ -42,7 +42,7 @@ def scandir(path, group_derived_series=False, symlinks=False, **kwargs):
         for fp in filepaths:
             try:
                 dcm = reaper.dcm.DicomFile(fp)
-            except dicom.errors.InvalidDicomError:
+            except reaper.dcm.DicomFileError:
                 log.info('    Ignoring non-DICOM file %s', fp)
                 continue
 
@@ -55,7 +55,7 @@ def scandir(path, group_derived_series=False, symlinks=False, **kwargs):
                 log.warning('%s does not contain all required DICOM UIDs - skipping', fp)
                 continue
 
-            acq_uid = primary_series_uid if primary_series_uid and group_derived_series else series_uid
+            acq_uid = primary_series_uid if primary_series_uid and group_related_series else series_uid
 
             subj_code = dcm.get_tag(field_names['subject_code'], 'Unknown')
             sess_label = dcm.get_tag(field_names['session_label'], 'Untitled')
@@ -78,7 +78,7 @@ def scandir(path, group_derived_series=False, symlinks=False, **kwargs):
             })
             ds['images'][image_uid] = fp
 
-            if group_derived_series and not primary_series_uid:
+            if group_related_series and not primary_series_uid:
                 acq['label'] = acq_label # force the label for primary series
 
     log.info('')
@@ -98,14 +98,14 @@ def emit_summary(sessions, project, group):
     log.warning('Will upload %d DICOM files as %d datasets', file_cnt, ds_cnt)
 
     if log.isEnabledFor(logging.INFO):
-        log.info('\nEstablished hierarchy:')
-        log.info('%s\n  %s', project, group)
+        log.info('\nDerived hierarchy')
+        log.info('  %s\n    %s', project, group)
         for sess in sessions.itervalues():
-            log.info('    ' + sess['label'] + ' >>> ' + sess['subject'])
+            log.info('      ' + sess['label'] + ' >>> ' + sess['subject'])
             for acq in sess['acquisitions'].itervalues():
-                log.info('      ' + acq['label'])
+                log.info('        ' + acq['label'])
                 for ds in acq['datasets'].itervalues():
-                    log.info('        %s (%d images)', ds['label'], len(ds['images']))
+                    log.info('          %s (%d images)', ds['label'], len(ds['images']))
         log.info('')
 
 
@@ -159,7 +159,7 @@ def main():
     auth_group.add_argument('--secret', help='shared API secret')
     auth_group.add_argument('--key', help='user API key')
 
-    arg_parser.add_argument('--group-series', action='store_true', help='group derived Series into the same Acquisition')
+    arg_parser.add_argument('--group-related-series', action='store_true', help='group derived Series into the same Acquisition')
     arg_parser.add_argument('--de-identify', action='store_true', help='de-identify data before upload')
     arg_parser.add_argument('--tag-override', nargs=2, action='append', default=[], help='DICOM tag override')
 
@@ -178,7 +178,7 @@ def main():
 
     tag_override = {k: v if v.lower() != 'null' else None for k, v in args.tag_override}
 
-    sessions = scandir(args.path, args.group_series, args.symlinks, **tag_override)
+    sessions = scandir(args.path, args.group_related_series, args.symlinks, **tag_override)
     emit_summary(sessions, args.group, args.project)
     if not args.yes:
         try:
@@ -186,6 +186,7 @@ def main():
         except KeyboardInterrupt:
             print
             sys.exit(1)
+    log.info('')
 
     try:
         #upsert_groups(groups, api_request) FIXME check for write access to project

--- a/bin/dicom_folder_sniper
+++ b/bin/dicom_folder_sniper
@@ -88,7 +88,7 @@ def scandir(path, group_related_series=False, de_identify=False, symlinks=False,
     return sessions
 
 
-def emit_summary(sessions, project, group):
+def emit_summary(sessions, project, group, de_identify=False):
     sess_cnt = len(sessions)
     acq_cnt = sum([len(sess['acquisitions']) for sess in sessions.itervalues()])
     file_cnt = ds_cnt = 0
@@ -98,7 +98,10 @@ def emit_summary(sessions, project, group):
                 file_cnt += len(ds['images'])
                 ds_cnt += 1
     log.warning('Found %d Acquisition(s) in %d Session(s)', acq_cnt, sess_cnt)
-    log.warning('Will upload %d DICOM files as %d datasets', file_cnt, ds_cnt)
+    if de_identify:
+        log.warning('Will De-Identify and upload %d DICOM files as %d datasets', file_cnt, ds_cnt)
+    else:
+        log.warning('Will upload %d DICOM files as %d datasets', file_cnt, ds_cnt)
 
     if log.isEnabledFor(logging.INFO):
         log.info('\nDerived hierarchy')
@@ -189,7 +192,7 @@ def main():
     tag_override = {k: v if v.lower() != 'null' else None for k, v in args.tag_override}
 
     sessions = scandir(args.path, args.group_related_series, args.de_identify, args.symlinks, **tag_override)
-    emit_summary(sessions, args.group, args.project)
+    emit_summary(sessions, args.group, args.project, args.de_identify)
     if not args.yes:
         try:
             raw_input('Press Enter to process and upload all data or Ctrl-C to abort...')

--- a/bin/dicom_folder_sniper
+++ b/bin/dicom_folder_sniper
@@ -9,8 +9,6 @@ import shutil
 import logging
 import argparse
 
-import dicom # FIXME should use reaper.dcm instead
-
 import reaper.dcm
 import reaper.util
 import reaper.upload
@@ -22,10 +20,20 @@ logging.basicConfig(
 log = logging.getLogger()
 
 
-def scandir(path, group_derived_series=False, symlinks=False):
+DEFAULT_FIELD_NAMES = {
+    'subject_code':         'PatientID',
+    'session_label':        'StudyDescription',
+    'acquisition_label':    'SeriesDescription',
+    'dataset_label_prefix': 'SeriesNumber',
+}
+
+
+def scandir(path, group_derived_series=False, symlinks=False, **kwargs):
+    field_names = DEFAULT_FIELD_NAMES
+    field_names.update(kwargs)
+
     log.warning('Scanning subfolders')
     sessions = {}
-
     for dirpath, dirnames, filenames in os.walk(path, followlinks=symlinks):
         dirnames[:] = [dn for dn in dirnames if not dn.startswith('.')] # use slice assignment to influence walk
         filepaths = [os.path.join(dirpath, fn) for fn in filenames if not fn.startswith('.')] # ignore dotfiles
@@ -33,29 +41,29 @@ def scandir(path, group_derived_series=False, symlinks=False):
 
         for fp in filepaths:
             try:
-                dcm = dicom.read_file(fp, stop_before_pixels=True)
+                dcm = reaper.dcm.DicomFile(fp)
             except dicom.errors.InvalidDicomError:
                 log.info('    Ignoring non-DICOM file %s', fp)
                 continue
 
             try:
-                study_uid = dcm.StudyInstanceUID
-                series_uid = dcm.SeriesInstanceUID
-                primary_series_uid = dcm.get('RelatedSeriesSequence', [{}])[0].get('SeriesInstanceUID')
-                image_uid = dcm.SOPInstanceUID
+                study_uid = dcm.raw.StudyInstanceUID
+                series_uid = dcm.raw.SeriesInstanceUID
+                primary_series_uid = dcm.raw.get('RelatedSeriesSequence', [{}])[0].get('SeriesInstanceUID')
+                image_uid = dcm.raw.SOPInstanceUID
             except AttributeError:
                 log.warning('%s does not contain all required DICOM UIDs - skipping', fp)
                 continue
 
             acq_uid = primary_series_uid if primary_series_uid and group_derived_series else series_uid
 
-            subj_id = dcm.get('PatientID') or 'Unknown'
-            sess_label = dcm.get('StudyDescription') or dcm.get('ProtocolName') or 'Untitled'
-            acq_label = dcm.get('SeriesDescription') or 'Untitled'
-            ds_label = (str(dcm.get('SeriesNumber')) or 'Unknown') + ' - ' +  acq_label
+            subj_code = dcm.get_tag(field_names['subject_code'], 'Unknown')
+            sess_label = dcm.get_tag(field_names['session_label'], 'Untitled')
+            acq_label = dcm.get_tag(field_names['acquisition_label'], 'Untitled')
+            ds_label = dcm.get_tag(field_names['dataset_label_prefix'], 'Unknown') + ' - ' +  acq_label
 
             sess = sessions.setdefault(study_uid, {
-                'subject': subj_id,
+                'subject': subj_code,
                 'label': sess_label,
                 'acquisitions': {},
             })
@@ -64,7 +72,7 @@ def scandir(path, group_derived_series=False, symlinks=False):
                 'datasets': {},
             })
             ds = acq['datasets'].setdefault(series_uid, {
-                'type': dcm.get('ImageType'), # for debug purposes only
+                'type': dcm.raw.get('ImageType'), # for debug purposes only
                 'label': ds_label,
                 'images': {},
             })
@@ -93,7 +101,7 @@ def emit_summary(sessions, project, group):
         log.info('\nEstablished hierarchy:')
         log.info('%s\n  %s', project, group)
         for sess in sessions.itervalues():
-            log.info('    ' + sess['label'])
+            log.info('    ' + sess['label'] + ' >>> ' + sess['subject'])
             for acq in sess['acquisitions'].itervalues():
                 log.info('      ' + acq['label'])
                 for ds in acq['datasets'].itervalues():
@@ -141,8 +149,6 @@ def main():
     arg_parser.add_argument('uri', help='API URL')
     arg_parser.add_argument('group', help='Group ID')
     arg_parser.add_argument('project', help='Project Name')
-    arg_parser.add_argument('-g', '--group-series', action='store_true', help='group derived Series into the same Acquisition')
-    arg_parser.add_argument('-d', '--de-identify', action='store_true', help='de-identify data before upload')
     arg_parser.add_argument('-i', '--insecure', action='store_true', help='do not verify server SSL certificates')
     arg_parser.add_argument('-y', '--yes', action='store_true', help='do not prompt to continue')
     arg_parser.add_argument('-l', '--loglevel', default='warning', help='log level [INFO]')
@@ -152,6 +158,10 @@ def main():
     auth_group = arg_parser.add_mutually_exclusive_group()
     auth_group.add_argument('--secret', help='shared API secret')
     auth_group.add_argument('--key', help='user API key')
+
+    arg_parser.add_argument('--group-series', action='store_true', help='group derived Series into the same Acquisition')
+    arg_parser.add_argument('--de-identify', action='store_true', help='de-identify data before upload')
+    arg_parser.add_argument('--tag-override', nargs=2, action='append', default=[], help='DICOM tag override')
 
     args = arg_parser.parse_args(sys.argv[1:] or ['--help'])
 
@@ -166,7 +176,9 @@ def main():
     secret_info = ('DICOM Folder Sniper', 'System Import', args.secret) if args.secret else None
     api_request, upload_function = reaper.upload.upload_function(args.uri, secret_info, args.key, args.root, args.insecure, '/upload/label')
 
-    sessions = scandir(args.path, args.group_series, args.symlinks)
+    tag_override = {k: v if v.lower() != 'null' else None for k, v in args.tag_override}
+
+    sessions = scandir(args.path, args.group_series, args.symlinks, **tag_override)
     emit_summary(sessions, args.group, args.project)
     if not args.yes:
         try:

--- a/bin/dicom_folder_sniper
+++ b/bin/dicom_folder_sniper
@@ -29,7 +29,7 @@ DEFAULT_FIELD_NAMES = {
 }
 
 
-def scandir(path, group_related_series=False, symlinks=False, de_identify=False, **kwargs):
+def scandir(path, group_related_series=False, de_identify=False, symlinks=False, **kwargs):
     field_names = DEFAULT_FIELD_NAMES
     field_names.update(kwargs)
 
@@ -60,7 +60,7 @@ def scandir(path, group_related_series=False, symlinks=False, de_identify=False,
             if not de_identify:
                 subj_code = dcm.get_tag(field_names['subject_code'], 'Unknown')
             else:
-                subj_code = 'ex' + dcm.get_tag(field_names['exam_number'], 'Unknown')
+                subj_code = 'ex' + dcm.get_tag(field_names['exam_number'], '0')
             sess_label = dcm.get_tag(field_names['session_label'], 'Untitled')
             acq_label = dcm.get_tag(field_names['acquisition_label'], 'Untitled')
             ds_label = dcm.get_tag(field_names['dataset_label_prefix'], 'Unknown') + ' - ' +  acq_label
@@ -164,9 +164,9 @@ def main():
     auth_group.add_argument('--key', help='user API key')
     arg_parser.add_argument('--root', action='store_true', help='send API requests as site admin')
 
-    arg_parser.add_argument('--group_related_series', action='store_true', help='group derived Series into the same Acquisition')
-    arg_parser.add_argument('--de_identify', action='store_true', help='de-identify data before upload')
-    arg_parser.add_argument('--tag_override', nargs=2, action='append', default=[], help='DICOM tag override')
+    arg_parser.add_argument('--group-related-series', action='store_true', help='group derived Series into the same Acquisition')
+    arg_parser.add_argument('--de-identify', action='store_true', help='de-identify data before upload')
+    arg_parser.add_argument('--tag-override', nargs=2, action='append', default=[], help='DICOM tag override')
 
     args = arg_parser.parse_args(sys.argv[1:] or ['--help'])
 
@@ -188,7 +188,7 @@ def main():
 
     tag_override = {k: v if v.lower() != 'null' else None for k, v in args.tag_override}
 
-    sessions = scandir(args.path, args.group_related_series, args.symlinks, args.de_identify, **tag_override)
+    sessions = scandir(args.path, args.group_related_series, args.de_identify, args.symlinks, **tag_override)
     emit_summary(sessions, args.group, args.project)
     if not args.yes:
         try:

--- a/bin/dicom_sniper
+++ b/bin/dicom_sniper
@@ -8,18 +8,16 @@ import logging
 import argparse
 import datetime
 
-## configure logging before reaper.util does
-logging.basicConfig(
-    format='%(message)s',
-    level=logging.INFO,
-)
-log = logging.getLogger('dicom_sniper')
-
 import reaper.dcm
 import reaper.scu
 import reaper.util
 import reaper.upload
 import reaper.tempdir as tempfile
+
+logging.basicConfig(
+    format='%(message)s',
+)
+log = logging.getLogger()
 
 
 arg_parser = argparse.ArgumentParser()

--- a/bin/dicom_sniper
+++ b/bin/dicom_sniper
@@ -82,7 +82,7 @@ if not args.yes:
     else:
         print
 
-_, upload_function = reaper.upload.upload_function(args.uri, ('sniper', args.aec, args.secret), insecure=args.insecure, upload_route='/api/upload/reaper')
+_, upload_function = reaper.upload.upload_function(args.uri, ('sniper', args.aec, args.secret), insecure=args.insecure, upload_route='/api/upload/uid')
 
 for series_uid, series_info in matched_series.iteritems():
     with tempfile.TemporaryDirectory() as tempdir:

--- a/bin/dicom_sniper
+++ b/bin/dicom_sniper
@@ -30,25 +30,28 @@ arg_parser.add_argument('uri', help='upload URI')
 arg_parser.add_argument('-A', '--no-anonymize', dest='anonymize', action='store_false', help='do not anonymize patient name and birthdate')
 arg_parser.add_argument('-i', '--insecure', action='store_true', help='do not verify server SSL certificates')
 arg_parser.add_argument('-k', '--query', nargs=2, action='append', default=[], help='query tuple')
-arg_parser.add_argument('-l', '--loglevel', default='info', help='log level [INFO]')
+arg_parser.add_argument('-l', '--loglevel', default='warning', help='log level [WARNING]')
 arg_parser.add_argument('-y', '--yes', action='store_true', help='do not prompt to continue')
 arg_parser.add_argument('-z', '--timezone', help='instrument timezone [system timezone]')
 arg_parser.add_argument('--map-key', default='PatientID', help='key for mapping info [PatientID], patterned as subject@group/project')
 
-auth_group = arg_parser.add_mutually_exclusive_group(required=True)
+auth_group = arg_parser.add_mutually_exclusive_group()
 auth_group.add_argument('--secret', help='shared API secret')
 auth_group.add_argument('--key', help='user API key')
+arg_parser.add_argument('--root', action='store_true', help='send API requests as site admin')
 
 args = arg_parser.parse_args(sys.argv[1:] or ['--help'])
 args.query = dict(args.query)
 
 args.timezone = reaper.util.validate_timezone(args.timezone)
 if args.timezone is None:
-    log.error('invalid timezone')
+    log.error('Invalid timezone')
     sys.exit(1)
 
 logging.root.setLevel(getattr(logging, args.loglevel.upper()))
 
+secret_info = ('DICOM Sniper', args.aec, args.secret) if args.secret else None
+_, upload_function = reaper.upload.upload_function(args.uri, secret_info, args.key, args.root, args.insecure, '/api/upload/uid')
 
 scu_ = reaper.scu.SCU(args.host, args.port, args.rport, args.aet, args.aec)
 
@@ -67,11 +70,11 @@ for study in scu_studies:
             'success': False,
         }
 matched_series_cnt = len(matched_series)
-log.info('Found %d DICOM Series in %d Studies', matched_series_cnt, len(scu_studies))
+log.warning('Found %d DICOM Series in %d Studies', matched_series_cnt, len(scu_studies))
 for study in sorted(scu_studies, key=lambda study: study.StudyDate + study.StudyTime):
-    log.info('  %s %s %s', study.StudyDate, study.StudyTime, study.StudyInstanceUID)
-    for series_uid in matched_series:
-        log.info('    %s', series_uid)
+    log.info('  %s %s: %s', study.StudyDate, study.StudyTime, study.StudyInstanceUID)
+    for series_uid, series in matched_series.iteritems():
+        log.info('    %s, %d images', series_uid, series['image_cnt'])
 
 if not args.yes:
     try:
@@ -82,13 +85,11 @@ if not args.yes:
     else:
         print
 
-_, upload_function = reaper.upload.upload_function(args.uri, ('sniper', args.aec, args.secret), insecure=args.insecure, upload_route='/api/upload/uid')
-
 for series_uid, series_info in matched_series.iteritems():
     with tempfile.TemporaryDirectory() as tempdir:
         reapdir = os.path.join(tempdir, 'reap')
         os.mkdir(reapdir)
-        log.info('Fetching     %s, %d images', series_uid, series_info['image_cnt'])
+        log.warning('Fetching     %s, %d images', series_uid, series_info['image_cnt'])
         start = datetime.datetime.utcnow()
         series_info['success'], _ = scu_.move(reaper.scu.SeriesQuery(SeriesInstanceUID=series_uid), reapdir)
         duration = (datetime.datetime.utcnow() - start).total_seconds()
@@ -98,6 +99,7 @@ for series_uid, series_info in matched_series.iteritems():
         else:
             log.error('Failure      %s', series_uid)
             continue
+        log.warning('Processing   %s', series_uid)
         metadata_map = reaper.dcm.pkg_series(series_uid, reapdir, args.map_key, None, args.anonymize, args.timezone)
         for filepath, metadata in metadata_map.iteritems():
             success = reaper.upload.metadata_upload(filepath, metadata, upload_function)

--- a/bin/dicom_sniper
+++ b/bin/dicom_sniper
@@ -27,13 +27,13 @@ arg_parser.add_argument('rport', help='local return port')
 arg_parser.add_argument('aet', help='local AE title')
 arg_parser.add_argument('aec', help='remote AE title')
 arg_parser.add_argument('uri', help='upload URI')
-arg_parser.add_argument('-A', '--no-anonymize', dest='anonymize', action='store_false', help='do not anonymize patient name and birthdate')
 arg_parser.add_argument('-i', '--insecure', action='store_true', help='do not verify server SSL certificates')
 arg_parser.add_argument('-k', '--query', nargs=2, action='append', default=[], help='query tuple')
 arg_parser.add_argument('-l', '--loglevel', default='warning', help='log level [WARNING]')
 arg_parser.add_argument('-y', '--yes', action='store_true', help='do not prompt to continue')
 arg_parser.add_argument('-z', '--timezone', help='instrument timezone [system timezone]')
 arg_parser.add_argument('--map-key', default='PatientID', help='key for mapping info [PatientID], patterned as subject@group/project')
+arg_parser.add_argument('--de-identify', action='store_true', help='de-identify data before upload')
 
 auth_group = arg_parser.add_mutually_exclusive_group()
 auth_group.add_argument('--secret', help='shared API secret')
@@ -100,7 +100,7 @@ for series_uid, series_info in matched_series.iteritems():
             log.error('Failure      %s', series_uid)
             continue
         log.warning('Processing   %s', series_uid)
-        metadata_map = reaper.dcm.pkg_series(series_uid, reapdir, args.map_key, None, args.anonymize, args.timezone)
+        metadata_map = reaper.dcm.pkg_series(series_uid, reapdir, args.map_key, None, args.de_identify, args.timezone)
         for filepath, metadata in metadata_map.iteritems():
             success = reaper.upload.metadata_upload(filepath, metadata, upload_function)
             if not success:

--- a/bin/folder_sniper
+++ b/bin/folder_sniper
@@ -13,14 +13,14 @@ import reaper.upload
 import reaper.tempdir as tempfile
 
 logging.basicConfig(
-    format='%(asctime)s %(levelname)8.8s %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S',
+    format='%(message)s',
 )
 log = logging.getLogger()
 
 
 def scan_folder(path, symlinks=False):
     projects = []
+    log.info('Inspecting  %s', path)
     for dirpath, dirnames, filenames in os.walk(path, followlinks=symlinks):
         filenames = [fn for fn in filenames if not fn.startswith('.')]      # ignore dotfiles
         dirnames[:] = [dn for dn in dirnames if not dn.startswith('.')]     # use slice assignment to influence walk
@@ -189,7 +189,10 @@ def main():
     if not os.path.isdir(args.path):
         log.error('Path        %s is not a directory or does not exist', args.path)
         sys.exit(1)
-    log.info('Inspecting  %s', args.path)
+
+    secret_info = ('Folder Sniper', 'System Import', args.secret) if args.secret else None
+    api_request, upload_function = reaper.upload.upload_function(args.uri, secret_info, args.key, args.root, args.insecure, '/api/upload/label')
+
     groups, projects = scan_folder(args.path, args.symlinks)
     if not args.yes:
         print_upload_summary(projects)
@@ -199,8 +202,6 @@ def main():
             print
             sys.exit(1)
 
-    secret_info = ('Folder Sniper', 'System Import', args.secret) if args.secret else None
-    api_request, upload_function = reaper.upload.upload_function(args.uri, secret_info, args.key, args.root, args.insecure, '/api/upload/label')
     try:
         upsert_groups(groups, api_request)
         process(projects, upload_function)

--- a/bin/folder_sniper
+++ b/bin/folder_sniper
@@ -20,7 +20,7 @@ log = logging.getLogger()
 
 def scan_folder(path, symlinks=False):
     projects = []
-    log.info('Inspecting  %s', path)
+    log.warning('Inspecting %s', path)
     for dirpath, dirnames, filenames in os.walk(path, followlinks=symlinks):
         filenames = [fn for fn in filenames if not fn.startswith('.')]      # ignore dotfiles
         dirnames[:] = [dn for dn in dirnames if not dn.startswith('.')]     # use slice assignment to influence walk
@@ -71,8 +71,8 @@ def print_upload_summary(projects):
             for acq in sess['acquisitions']:
                 file_cnt += len(acq['files'])
                 packfile_cnt += len(acq['packfiles'])
-    log.info('Found %d Session(s) in %d Project(s) in %d Group(s)', session_cnt, len(projects), group_cnt)
-    log.info('Will upload %d regular file(s) and %d pack file(s)', file_cnt, packfile_cnt)
+    log.warning('Found %d Session(s) in %d Project(s) in %d Group(s)', session_cnt, len(projects), group_cnt)
+    log.warning('Will upload %d regular file(s) and %d pack file(s)', file_cnt, packfile_cnt)
 
 
 def file_metadata(f, **kwargs):
@@ -87,7 +87,7 @@ def upsert_groups(groups, api_request):
     for group in groups:
         success = api_request('post', '/groups', json={'_id': group.lower()})
         if success:
-            log.info('Upserted group ' + group)
+            log.warning('Upserted group ' + group)
         else:
             log.error('Failed to upsert group ' + group + '. Trying to proceed anyway.')
 
@@ -100,44 +100,44 @@ def process(projects, upload_func):
         group = project['group']
         p_label = group + ' > ' + project['label']
         metadata = {'group': {'_id': group}, 'project': {'label': project['label']}}
-        log.info(action_str, '', p_label)
+        log.warning(action_str, '', p_label)
         for f in project['files']:
-            log.info(file_str, 'Uploading', f['path'])
+            log.warning(file_str, 'Uploading', f['path'])
             metadata['project']['files'] = [file_metadata(f)]
             upload_func(f['path'], metadata)
         metadata['project'].pop('files', [])
         for session in project['sessions']:
             s_label = p_label + ' > ' + session['label']
-            log.info(action_str, '', s_label)
+            log.warning(action_str, '', s_label)
             subj_files = session['subject'].pop('files', [])
             metadata.update({'session': {'label': session['label'], 'subject': session['subject']}})
             for f in session['files']:
-                log.info(file_str, 'Uploading', f['path'])
+                log.warning(file_str, 'Uploading', f['path'])
                 metadata['session']['files'] = [file_metadata(f)]
                 upload_func(f['path'], metadata)
             for f in subj_files:
-                log.info(file_str, 'Uploading', f['path'])
+                log.warning(file_str, 'Uploading', f['path'])
                 metadata['session']['subject']['files'] = [file_metadata(f)]
                 upload_func(f['path'], metadata)
             metadata['session'].pop('files', [])
             metadata['session']['subject'].pop('files', [])
             for acquisition in session['acquisitions']:
                 a_label = s_label + ' > ' + acquisition['label']
-                log.info(action_str, '', a_label)
+                log.warning(action_str, '', a_label)
                 metadata.update({'acquisition': {'label': acquisition['label']}})
                 for f in acquisition['files']:
-                    log.info(file_str, 'Uploading', f['path'])
+                    log.warning(file_str, 'Uploading', f['path'])
                     metadata['acquisition']['files'] = [file_metadata(f)]
                     upload_func(f['path'], metadata)
                 metadata['acquisition'].pop('files', [])
-                log.info(action_str, 'pack-', a_label)
+                log.warning(action_str, 'pack-', a_label)
                 for f in acquisition['packfiles']:
                     with tempfile.TemporaryDirectory() as tempdir:
-                        log.info(file_str, 'Packing', f['path'])
+                        log.warning(file_str, 'Packing', f['path'])
                         arcname = acquisition['label'] + '.' + f['type']
                         fp = reaper.util.create_archive(f['path'], arcname, None, tempdir)
                         metadata['acquisition']['files'] = [file_metadata(f, name=os.path.basename(fp))]
-                        log.info(file_str, 'Uploading', f['path'])
+                        log.warning(file_str, 'Uploading', f['path'])
                         upload_func(fp, metadata)
                 metadata['acquisition'].pop('files', [])
 
@@ -172,7 +172,7 @@ def main():
     arg_parser.add_argument('uri', help='API URL')
     arg_parser.add_argument('-i', '--insecure', action='store_true', help='do not verify server SSL certificates')
     arg_parser.add_argument('-y', '--yes', action='store_true', help='do not prompt to continue')
-    arg_parser.add_argument('-l', '--loglevel', default='info', help='log level [INFO]')
+    arg_parser.add_argument('-l', '--loglevel', default='warning', help='log level [WARNING]')
     arg_parser.add_argument('-s', '--symlinks', action='store_true', help='follow symbolic links that resolve to directories')
     arg_parser.add_argument('--root', action='store_true', help='send API requests as site admin')
 
@@ -187,7 +187,7 @@ def main():
 
     args.path = os.path.expanduser(args.path)
     if not os.path.isdir(args.path):
-        log.error('Path        %s is not a directory or does not exist', args.path)
+        log.critical('Path        %s is not a directory or does not exist', args.path)
         sys.exit(1)
 
     secret_info = ('Folder Sniper', 'System Import', args.secret) if args.secret else None

--- a/reaper/dcm.py
+++ b/reaper/dcm.py
@@ -104,9 +104,9 @@ class DicomFile(object):
                 if dob and study_datetime:
                     months = 12 * (study_datetime.year - dob.year) + (study_datetime.month - dob.month) - (study_datetime.day < dob.day)
                     dcm.PatientAge = '%03dM' % months if months < 960 else '%03dY' % (months / 12)
-            dcm.pop('PatientBirthDate', None)
-            dcm.pop('PatientName', None)
-            dcm.pop('PatientID', None)
+            dcm.PatientBirthDate = ''
+            dcm.PatientName = ''
+            dcm.PatientID = ''
             dcm.save_as(filepath)
 
     def get_tag(self, tag_name, default=None):

--- a/reaper/dcm.py
+++ b/reaper/dcm.py
@@ -2,7 +2,6 @@
 
 import os
 import shutil
-import hashlib
 import logging
 import datetime
 
@@ -90,8 +89,6 @@ class DicomFile(object):
             self.session_uid = dcm.get('StudyInstanceUID')
             self.session_timestamp = study_datetime
             self.subject_firstname, self.subject_lastname = self.__parse_patient_name(dcm.get('PatientName', ''))
-            self.subject_firstname_hash = hashlib.sha256(self.subject_firstname).hexdigest() if self.subject_firstname else None
-            self.subject_lastname_hash = hashlib.sha256(self.subject_lastname).hexdigest() if self.subject_lastname else None
             self.subject_code, self.group__id, self.project_label = util.parse_sorting_info(self._id, 'ex' + dcm.get('StudyID', ''))
             self.acquisition_uid = series_uid + ('_' + str(self.acq_no) if self.acq_no is not None else '')
             self.acquisition_timestamp = acq_datetime or study_datetime

--- a/reaper/dcm.py
+++ b/reaper/dcm.py
@@ -65,7 +65,7 @@ class DicomFile(object):
     # pylint: disable=too-few-public-methods
 
     def __init__(self, filepath, map_key=None, opt_key=None, parse=False, de_identify=False, timezone=None):
-        dcm = dicom.read_file(filepath, stop_before_pixels=(not de_identify))
+        self.raw = dcm = dicom.read_file(filepath, stop_before_pixels=(not de_identify))
         self._id = dcm.get(map_key, '') if opt_key else None
         self.opt = dcm.get(opt_key, '') if opt_key else None
         self.acq_no = str(dcm.get('AcquisitionNumber', '')) or None if dcm.get('Manufacturer').upper() != 'SIEMENS' else None
@@ -99,6 +99,11 @@ class DicomFile(object):
             if dcm.get('PatientName'):
                 del dcm.PatientName
             dcm.save_as(filepath)
+
+    def get_tag(self, tag_name, default=None):
+        if tag_name:
+            return str(self.raw.get(tag_name)).strip('\x00') or default
+        return default
 
     @staticmethod
     def __is_screenshot(image_type):

--- a/reaper/dcm.py
+++ b/reaper/dcm.py
@@ -80,6 +80,8 @@ class DicomFile(object):
         self.acq_no = str(dcm.get('AcquisitionNumber', '')) or None if dcm.get('Manufacturer').upper() != 'SIEMENS' else None
 
         if parse or de_identify:
+            if not timezone:
+                timezone = util.validate_timezone(None)
             series_uid = dcm.get('SeriesInstanceUID')
             if self.__is_screenshot(dcm.get('ImageType')):
                 front, back = series_uid.rsplit('.', 1)
@@ -101,7 +103,7 @@ class DicomFile(object):
             self.subject_firstname = self.subject_lastname = None
             if dcm.get('PatientBirthDate'):
                 dob = self.__parse_patient_dob(dcm.PatientBirthDate)
-                if dob:
+                if dob and study_datetime:
                     months = 12 * (study_datetime.year - dob.year) + (study_datetime.month - dob.month) - (study_datetime.day < dob.day)
                     dcm.PatientAge = '%03dM' % months if months < 960 else '%03dY' % (months / 12)
             dcm.pop('PatientBirthDate', None)

--- a/reaper/dcm.py
+++ b/reaper/dcm.py
@@ -20,7 +20,6 @@ GEMS_TYPE_VXTL = ['DERIVED', 'SECONDARY', 'VXTL STATE']
 def pkg_series(_id, path, map_key, opt_key=None, de_identify=False, timezone=None):
     # pylint: disable=missing-docstring
     dcm_dict = {}
-    log.debug('Inspecting   %s', _id)
     start = datetime.datetime.utcnow()
     filepaths = [os.path.join(path, filename) for filename in os.listdir(path)]
     file_cnt = len(filepaths)
@@ -29,7 +28,6 @@ def pkg_series(_id, path, map_key, opt_key=None, de_identify=False, timezone=Non
         dcm_dict.setdefault(dcm.acq_no, []).append(filepath)
     duration = (datetime.datetime.utcnow() - start).total_seconds()
     log.info('Inspected    %s, %d images in %.1fs [%.0f/s]', _id, file_cnt, duration, file_cnt / duration)
-    log.debug('Compressing  %s%s', _id, ' (and anonymizing)' if de_identify else '')
     metadata_map = {}
     start = datetime.datetime.utcnow()
     for acq_no, acq_paths in dcm_dict.iteritems():
@@ -52,7 +50,7 @@ def pkg_series(_id, path, map_key, opt_key=None, de_identify=False, timezone=Non
         metadata_map[arc_path] = metadata
     duration = (datetime.datetime.utcnow() - start).total_seconds()
     log.info('Compressed   %s%s, %d images in %.1fs [%.0f/s]',
-             _id, ' (and anonymized)' if de_identify else '', file_cnt, duration, file_cnt / duration)
+             _id, ', de-id\'ed' if de_identify else '', file_cnt, duration, file_cnt / duration)
     return metadata_map
 
 

--- a/reaper/dcm.py
+++ b/reaper/dcm.py
@@ -56,6 +56,11 @@ def pkg_series(_id, path, map_key, opt_key=None, de_identify=False, timezone=Non
     return metadata_map
 
 
+class DicomFileError(dicom.errors.InvalidDicomError):
+    """DicomFileError class"""
+    pass
+
+
 class DicomFile(object):
 
     """
@@ -65,7 +70,11 @@ class DicomFile(object):
     # pylint: disable=too-few-public-methods
 
     def __init__(self, filepath, map_key=None, opt_key=None, parse=False, de_identify=False, timezone=None):
-        self.raw = dcm = dicom.read_file(filepath, stop_before_pixels=(not de_identify))
+        try:
+            self.raw = dcm = dicom.read_file(filepath, stop_before_pixels=(not de_identify))
+        except dicom.errors.InvalidDicomError:
+            raise DicomFileError()
+
         self._id = dcm.get(map_key, '') if opt_key else None
         self.opt = dcm.get(opt_key, '') if opt_key else None
         self.acq_no = str(dcm.get('AcquisitionNumber', '')) or None if dcm.get('Manufacturer').upper() != 'SIEMENS' else None
@@ -95,12 +104,13 @@ class DicomFile(object):
                 if dob:
                     months = 12 * (study_datetime.year - dob.year) + (study_datetime.month - dob.month) - (study_datetime.day < dob.day)
                     dcm.PatientAge = '%03dM' % months if months < 960 else '%03dY' % (months / 12)
-                del dcm.PatientBirthDate
-            if dcm.get('PatientName'):
-                del dcm.PatientName
+            dcm.pop('PatientBirthDate', None)
+            dcm.pop('PatientName', None)
+            dcm.pop('PatientID', None)
             dcm.save_as(filepath)
 
     def get_tag(self, tag_name, default=None):
+        # pylint: disable=missing-docstring
         if tag_name:
             return str(self.raw.get(tag_name)).strip('\x00') or default
         return default

--- a/reaper/dcm.py
+++ b/reaper/dcm.py
@@ -104,9 +104,9 @@ class DicomFile(object):
                 if dob and study_datetime:
                     months = 12 * (study_datetime.year - dob.year) + (study_datetime.month - dob.month) - (study_datetime.day < dob.day)
                     dcm.PatientAge = '%03dM' % months if months < 960 else '%03dY' % (months / 12)
-            dcm.PatientBirthDate = ''
-            dcm.PatientName = ''
-            dcm.PatientID = ''
+            del dcm.PatientBirthDate
+            del dcm.PatientName
+            del dcm.PatientID
             dcm.save_as(filepath)
 
     def get_tag(self, tag_name, default=None):

--- a/reaper/dcm.py
+++ b/reaper/dcm.py
@@ -49,8 +49,9 @@ def pkg_series(_id, path, map_key, opt_key=None, de_identify=False, timezone=Non
         shutil.rmtree(arcdir_path)
         metadata_map[arc_path] = metadata
     duration = (datetime.datetime.utcnow() - start).total_seconds()
-    log.info('Compressed   %s%s, %d images in %.1fs [%.0f/s]',
-             _id, ', de-id\'ed' if de_identify else '', file_cnt, duration, file_cnt / duration)
+    if de_identify:
+        log.info('De-id\'ed     %s, %d images', _id, file_cnt)
+    log.info('Compressed   %s, %d images in %.1fs [%.0f/s]', _id, file_cnt, duration, file_cnt / duration)
     return metadata_map
 
 

--- a/reaper/dicom_reaper.py
+++ b/reaper/dicom_reaper.py
@@ -18,7 +18,7 @@ class DicomReaper(reaper.Reaper):
     def __init__(self, options):
         self.scu = scu.SCU(options.get('host'), options.get('port'), options.get('return_port'), options.get('aet'), options.get('aec'))
         super(DicomReaper, self).__init__(self.scu.aec, options)
-        self.anonymize = options.get('anonymize')
+        self.de_identify = options.get('de_identify')
 
         self.query_tags = {self.map_key: ''}
         if self.opt_key is not None:
@@ -78,7 +78,7 @@ class DicomReaper(reaper.Reaper):
                 return None, {}
         if success and reap_cnt == item['state']['images']:
             log.warning('Processing   %s', self.state_str(_id))
-            metadata_map = dcm.pkg_series(_id, reapdir, self.map_key, self.opt_key, self.anonymize, self.timezone)
+            metadata_map = dcm.pkg_series(_id, reapdir, self.map_key, self.opt_key, self.de_identify, self.timezone)
             return True, metadata_map
         else:
             return False, {}
@@ -92,7 +92,7 @@ def update_arg_parser(ap):
     ap.add_argument('aet', help='local AE title')
     ap.add_argument('aec', help='remote AE title')
 
-    ap.add_argument('-A', '--no-anonymize', dest='anonymize', action='store_false', help='do not anonymize patient name and birthdate')
+    ap.add_argument('--de-identify', action='store_true', help='de-identify data before upload')
 
     return ap
 

--- a/reaper/dicom_reaper.py
+++ b/reaper/dicom_reaper.py
@@ -24,8 +24,11 @@ class DicomReaper(reaper.Reaper):
         if self.opt_key is not None:
             self.query_tags[self.opt_key] = ''
 
-    def state_str(self, _id, state):
-        return '%s (%s)' % (_id, ', '.join(['%s %s' % (v, k or 'null') for k, v in state.iteritems()]))
+    def state_str(self, _id, state=None):
+        if state:
+            return _id + ', ' + ', '.join(['%s %s' % (v, k or 'null') for k, v in state.iteritems()])
+        else:
+            return _id
 
     def instrument_query(self):
         i_state = {}
@@ -56,14 +59,14 @@ class DicomReaper(reaper.Reaper):
 
     def reap(self, _id, item, tempdir):
         if item['state']['images'] == 0:
-            log.info('Ignoring     %s (zero images)', _id)
+            log.warning('Ignoring     %s (zero images)', _id)
             return None, {}
         if not self.is_desired_item(item['state']['opt']):
-            log.info('Ignoring     %s (non-matching opt-%s)', _id, self.opt)
+            log.warning('Ignoring     %s (non-matching opt-%s)', _id, self.opt)
             return None, {}
         reapdir = os.path.join(tempdir, 'raw_dicoms')
         os.mkdir(reapdir)
-        log.info('Reaping      %s', self.state_str(_id, item['state']))
+        log.warning('Reaping      %s', self.state_str(_id, item['state']))
         start = datetime.datetime.utcnow()
         success, reap_cnt = self.scu.move(scu.SeriesQuery(SeriesInstanceUID=_id), reapdir)
         duration = (datetime.datetime.utcnow() - start).total_seconds()
@@ -71,9 +74,10 @@ class DicomReaper(reaper.Reaper):
         if success and reap_cnt > 0:
             df = dcm.DicomFile(os.path.join(reapdir, os.listdir(reapdir)[0]), self.map_key, self.opt_key)
             if not self.is_desired_item(df.opt):
-                log.info('Ignoring     %s (non-matching opt-%s)', _id, self.opt)
+                log.warning('Ignoring     %s (non-matching opt-%s)', _id, self.opt)
                 return None, {}
         if success and reap_cnt == item['state']['images']:
+            log.warning('Processing   %s', self.state_str(_id))
             metadata_map = dcm.pkg_series(_id, reapdir, self.map_key, self.opt_key, self.anonymize, self.timezone)
             return True, metadata_map
         else:

--- a/reaper/reaper.py
+++ b/reaper/reaper.py
@@ -14,6 +14,11 @@ from . import util
 from . import upload
 from . import tempdir as tempfile
 
+logging.basicConfig(
+    format='%(asctime)s %(name)16.16s:%(levelname)4.4s %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S',
+    level=logging.INFO,
+)
 log = logging.getLogger('reaper')
 
 SLEEPTIME = 60

--- a/reaper/upload.py
+++ b/reaper/upload.py
@@ -118,7 +118,7 @@ def __http_upload(url, secret_info, key, root, insecure, upload_route):
 def __request_session(secret_info, key, root, insecure):
     # pylint: disable=missing-docstring
     if insecure:
-        requests.urllib3.disable_warnings()
+        requests.packages.urllib3.disable_warnings()
     rs = requests.Session()
     if secret_info:
         rs.headers['X-SciTran-Method'] = secret_info[0]

--- a/reaper/upload.py
+++ b/reaper/upload.py
@@ -54,14 +54,14 @@ def upload_many(metadata_map, upload_func):
 def metadata_upload(filepath, metadata, upload_func):
     # pylint: disable=missing-docstring
     filename = os.path.basename(filepath)
-    log.info('Uploading    %s [%s]', filename, util.hrsize(os.path.getsize(filepath)))
+    log.warning('Uploading    %s [%s]', filename, util.hrsize(os.path.getsize(filepath)))
     start = datetime.datetime.utcnow()
     success = upload_func(filepath, metadata)
     duration = (datetime.datetime.utcnow() - start).total_seconds()
     if success:
-        log.warning('Uploaded     %s [%s/s]', filename, util.hrsize(os.path.getsize(filepath) / duration))
+        log.info('Uploaded     %s [%s/s]', filename, util.hrsize(os.path.getsize(filepath) / duration))
     else:
-        log.warning('Failure      %s', filename)
+        log.error('Failure      %s', filename)
     return success
 
 

--- a/reaper/upload.py
+++ b/reaper/upload.py
@@ -4,9 +4,9 @@ import os
 import json
 import array
 import logging
-import httplib
 import datetime
 
+import httplib
 import requests
 import requests_toolbelt
 
@@ -118,7 +118,7 @@ def __http_upload(url, secret_info, key, root, insecure, upload_route):
 def __request_session(secret_info, key, root, insecure):
     # pylint: disable=missing-docstring
     if insecure:
-        requests.packages.urllib3.disable_warnings()
+        requests.urllib3.disable_warnings()
     rs = requests.Session()
     if secret_info:
         rs.headers['X-SciTran-Method'] = secret_info[0]

--- a/reaper/upload.py
+++ b/reaper/upload.py
@@ -54,14 +54,14 @@ def upload_many(metadata_map, upload_func):
 def metadata_upload(filepath, metadata, upload_func):
     # pylint: disable=missing-docstring
     filename = os.path.basename(filepath)
-    log.debug('Uploading    %s [%s]', filename, util.hrsize(os.path.getsize(filepath)))
+    log.info('Uploading    %s [%s]', filename, util.hrsize(os.path.getsize(filepath)))
     start = datetime.datetime.utcnow()
     success = upload_func(filepath, metadata)
     duration = (datetime.datetime.utcnow() - start).total_seconds()
     if success:
-        log.info('Uploaded     %s [%s/s]', filename, util.hrsize(os.path.getsize(filepath) / duration))
+        log.warning('Uploaded     %s [%s/s]', filename, util.hrsize(os.path.getsize(filepath) / duration))
     else:
-        log.info('Failure      %s', filename)
+        log.warning('Failure      %s', filename)
     return success
 
 
@@ -88,12 +88,12 @@ def __http_upload(url, secret_info, key, root, insecure, upload_route):
         try:
             r = http_session.request(method, url + route, **kwargs)
         except requests.exceptions.ConnectionError as ex:
-            log.error('error        %s', ex)
+            log.error('Error        %s', ex)
             return False
         if r.ok:
             return True
         else:
-            log.warning('failure      %s %s', r.status_code, r.reason)
+            log.error('Failure      %s %s', r.status_code, r.reason)
             return False
 
     def upload(filepath, metadata):
@@ -104,12 +104,12 @@ def __http_upload(url, secret_info, key, root, insecure, upload_route):
             try:
                 r = http_session.post(url + upload_route, data=mpe, headers={'Content-Type': mpe.content_type})
             except requests.exceptions.ConnectionError as ex:
-                log.error('error        %s: %s', filename, ex)
+                log.error('Error        %s: %s', filename, ex)
                 return False
             if r.ok:
                 return True
             else:
-                log.warning('failure      %s: %s %s', filename, r.status_code, r.reason)
+                log.error('Failure      %s: %s %s', filename, r.status_code, r.reason)
                 return False
 
     return request, upload

--- a/reaper/upload.py
+++ b/reaper/upload.py
@@ -70,7 +70,7 @@ def upload_function(uri, secret_info=None, key=None, root=False, insecure=False,
     """Helper to get an appropriate upload function based on protocol"""
     if uri.startswith('http://') or uri.startswith('https://'):
         return __http_upload(uri.strip('/'), secret_info, key, root, insecure, upload_route)
-    elif uri.startswith('testing://'):
+    elif uri.startswith('dummy://'):
         return lambda method, route, **kwargs: True, lambda filepath, metadata: True
     elif uri.startswith('s3://'):
         return __s3_upload

--- a/reaper/util.py
+++ b/reaper/util.py
@@ -105,10 +105,10 @@ def read_state_file(path):
             state = json.load(fd, object_hook=datetime_decoder)
         # TODO add some consistency checks here and possibly drop state if corrupt
     except IOError:
-        log.warning('state file not found')
+        log.warning('State file not found')
         state = {}
     except ValueError:
-        log.warning('state file corrupt')
+        log.warning('State file corrupt')
         state = {}
     return state
 

--- a/reaper/util.py
+++ b/reaper/util.py
@@ -30,8 +30,6 @@ METADATA = [
     ('session', 'operator'),
     ('subject', 'firstname'),
     ('subject', 'lastname'),
-    ('subject', 'firstname_hash'),  # unrecoverable, if anonymizing
-    ('subject', 'lastname_hash'),   # unrecoverable, if anonymizing
     ('subject', 'sex'),
     ('subject', 'age'),
     ('acquisition', 'instrument'),

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ import os
 from setuptools import setup, find_packages
 
 install_requires = [
-    'pydicom',
-    'python-dateutil',
-    'pytz',
-    'requests',
-    'requests_toolbelt',
-    'tzlocal',
+    'pydicom==0.9.9',
+    'python-dateutil==2.6.0',
+    'pytz==2017.2',
+    'requests==2.17.3',
+    'requests_toolbelt==0.8.0',
+    'tzlocal==1.4',
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ install_requires = [
     'pydicom==0.9.9',
     'python-dateutil==2.6.0',
     'pytz==2017.2',
-    'requests==2.17.3',
+    'requests<2.17',
     'requests_toolbelt==0.8.0',
     'tzlocal==1.4',
 ]

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,3 +1,3 @@
-pep8
-pylint
-uwsgi
+pep8==1.7.0
+pylint==1.7.1
+uwsgi==2.0.15


### PR DESCRIPTION
The primary purpose of this PR is to add the DICOM folder sniper. This new code has been reviewed and tested by @lmperry and does not require further detailed review.

Logging for all tools was also adapted and should be reviewed carefully.

All tools are now generally expected to run at the new default log level, *warning*. The *info* level should be slightly more chatty, and the *debug* level should be reserved for actual debugging activities.

The user-facing *snipers* use a different log format than the automated *reapers*. Tools can now control their own log format more easily.

*Anonymization* terminology was partially changed to a more accurate *de-identification*. That change should be propagated throughout the code before merging this PR.

I further propose that de-identification not be turned on by default. Handled data should not be manipulated in any way without the user's explicit consent. @ryansanford @lmperry Thoughts?